### PR TITLE
assumeInteractiveReceiver should return MaybeInputsOwned in stead of receive.MaybeInputsOwned

### DIFF
--- a/lib/receive/v1.dart
+++ b/lib/receive/v1.dart
@@ -56,7 +56,7 @@ class UncheckedProposal extends receive.UncheckedProposal {
   ///Call this method if the only way to initiate a Payjoin with this receiver requires manual intervention, as in most consumer wallets.
   /// So-called “non-interactive” receivers, like payment processors,
   /// that allow arbitrary requests are otherwise vulnerable to probing attacks. Those receivers call gettransactiontocheckbroadcast() and attesttestedandscheduledbroadcast() after making those checks downstream
-  Future<receive.MaybeInputsOwned> assumeInteractiveReceiver() async {
+  Future<MaybeInputsOwned> assumeInteractiveReceiver() async {
     try {
       final res =
           await receive.UncheckedProposal.assumeInteractiveReceiver(ptr: this);


### PR DESCRIPTION
It should be possible to call `checkInputsNotOwned`  on the return value of the `assumeInteractiveReceiver` function, but currently this is not possible because the function returns `receive.MaybeInputsOwned` instead of just `MaybeInputsOwned`. This PR fixes this.

