### PR TITLE
Separate receiver and sender logic in steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,47 @@
+## [0.13.0-dev.2]
+
+### Fixed
+
+- Fix `assumeInteractiveReceiver` return type
+
+### Refactor
+
+- Separate receiver and sender logic in example app.
+
 ## [0.13.0]
 
 ### Features & Modules
+
 #### Send module
-- #####  V1
-    - `RequestBuilder` exposes `fromPsbtAndUri`, `buildWithAdditionalFee`, `buildRecommended`, `buildNonIncentivizing`, `alwaysDisableOutputSubstitution`.
-    - `RequestContext` exposes `extractContextV1` & `extractContextV2`.
-    - `ContextV1` exposes `processResponse`.
-- ##### V2 
-    - `ContextV2` exposes `processResponse`.
+
+- ##### V1
+  - `RequestBuilder` exposes `fromPsbtAndUri`, `buildWithAdditionalFee`, `buildRecommended`, `buildNonIncentivizing`, `alwaysDisableOutputSubstitution`.
+  - `RequestContext` exposes `extractContextV1` & `extractContextV2`.
+  - `ContextV1` exposes `processResponse`.
+- ##### V2
+  - `ContextV2` exposes `processResponse`.
+
 #### Receive module
-- #####  V1
-    - `UncheckedProposal` exposes `fromRequest`, `extractTxToScheduleBroadcast`, `checkBroadcastSuitability`, `buildNonIncentivizing`, 
-        `assumeInteractiveReceiver` &`alwaysDisableOutputSubstitution`.
-    - `MaybeInputsOwned` exposes `checkInputsNotOwned`.    
-    - `MaybeMixedInputScripts` exposes `checkNoMixedInputScripts`.    
-    - `MaybeInputsSeen` exposes `checkNoInputsSeenBefore`.   
-    - `OutputsUnknown` exposes `identifyReceiverOutputs`.   
-    - `ProvisionalProposal` exposes `substituteOutputAddress`, `contributeNonWitnessInput`, `contributeWitnessInput`, `tryPreservingPrivacy` & 
-        `finalizeProposal`.
-    - `PayjoinProposal` exposes `isOutputSubstitutionDisabled`, `ownedVouts`, `psbt` & `utxosToBeLocked`.   
-- ##### V2 
-    - `Enroller` exposes `fromDirectoryConfig`, `processResponse` & `extractRequest`.
-    - `Enrolled` exposes `extractRequest`, `processResponse` & `fallbackTarget`.
-    - `UncheckedProposal` exposes  `extractTxToScheduleBroadcast`, `checkBroadcastSuitability` & `assumeInteractiveReceiver`.
-    - `MaybeInputsOwned` exposes `checkInputsNotOwned`.    
-    - `MaybeMixedInputScripts` exposes `checkNoMixedInputScripts`.    
-    - `MaybeInputsSeen` exposes `checkNoInputsSeenBefore`.   
-    - `OutputsUnknown` exposes `identifyReceiverOutputs`.   
-    - `ProvisionalProposal` exposes `substituteOutputAddress`, `contributeNonWitnessInput`, `contributeWitnessInput`, `tryPreservingPrivacy` & 
-        `finalizeProposal`.
-    - `PayjoinProposal` exposes `deserializeRes`, `extractV1Req`, `extractV2Request`, `isOutputSubstitutionDisabled`, `ownedVouts`, `psbt` &
-        `utxosToBeLocked`.     
+
+- ##### V1
+  - `UncheckedProposal` exposes `fromRequest`, `extractTxToScheduleBroadcast`, `checkBroadcastSuitability`, `buildNonIncentivizing`,
+    `assumeInteractiveReceiver` &`alwaysDisableOutputSubstitution`.
+  - `MaybeInputsOwned` exposes `checkInputsNotOwned`.
+  - `MaybeMixedInputScripts` exposes `checkNoMixedInputScripts`.
+  - `MaybeInputsSeen` exposes `checkNoInputsSeenBefore`.
+  - `OutputsUnknown` exposes `identifyReceiverOutputs`.
+  - `ProvisionalProposal` exposes `substituteOutputAddress`, `contributeNonWitnessInput`, `contributeWitnessInput`, `tryPreservingPrivacy` &
+    `finalizeProposal`.
+  - `PayjoinProposal` exposes `isOutputSubstitutionDisabled`, `ownedVouts`, `psbt` & `utxosToBeLocked`.
+- ##### V2
+  - `Enroller` exposes `fromDirectoryConfig`, `processResponse` & `extractRequest`.
+  - `Enrolled` exposes `extractRequest`, `processResponse` & `fallbackTarget`.
+  - `UncheckedProposal` exposes `extractTxToScheduleBroadcast`, `checkBroadcastSuitability` & `assumeInteractiveReceiver`.
+  - `MaybeInputsOwned` exposes `checkInputsNotOwned`.
+  - `MaybeMixedInputScripts` exposes `checkNoMixedInputScripts`.
+  - `MaybeInputsSeen` exposes `checkNoInputsSeenBefore`.
+  - `OutputsUnknown` exposes `identifyReceiverOutputs`.
+  - `ProvisionalProposal` exposes `substituteOutputAddress`, `contributeNonWitnessInput`, `contributeWitnessInput`, `tryPreservingPrivacy` &
+    `finalizeProposal`.
+  - `PayjoinProposal` exposes `deserializeRes`, `extractV1Req`, `extractV2Request`, `isOutputSubstitutionDisabled`, `ownedVouts`, `psbt` &
+    `utxosToBeLocked`.

--- a/example/integration_test/bitcoin_core_full_cycle_test.dart
+++ b/example/integration_test/bitcoin_core_full_cycle_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:payjoin_flutter/common.dart' as common;
+import 'package:payjoin_flutter/send.dart';
 import 'package:payjoin_flutter/uri.dart' as pay_join_uri;
 import 'package:payjoin_flutter_example/btc_client.dart';
 import 'package:payjoin_flutter_example/payjoin_library.dart';
@@ -35,11 +36,15 @@ void main() {
       final amount = await uri.amount();
       final senderPsbt =
           (await sender.walletCreateFundedPsbt(amount, address, 2000))["psbt"];
+      final requestContext = await (await RequestBuilder.fromPsbtAndUri(
+              psbtBase64: senderPsbt, uri: uri))
+          .buildRecommended(minFeeRate: 0);
+      final (_, ctx) = await requestContext.extractContextV1();
       debugPrint(
         "\nOriginal sender psbt: $senderPsbt",
       );
-      final (provisionalProposal, ctx) =
-          await payJoinLib.handlePjRequest(senderPsbt, pjUri, (e) async {
+      final provisionalProposal =
+          await payJoinLib.handlePjRequest(senderPsbt, (e) async {
         final script = ScriptBuf(bytes: e);
         final address = await (await Address.fromScript(
                 script: script, network: Network.regtest))

--- a/example/lib/bdk_client.dart
+++ b/example/lib/bdk_client.dart
@@ -82,8 +82,6 @@ class BdkClient {
 
   Future<int> getBalance() async {
     final balance = await wallet.getBalance();
-    final res = "Total Balance: ${balance.total.toString()}";
-    debugPrint(res);
     return balance.total;
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -131,7 +131,7 @@ class _PayJoinState extends State<PayJoin> {
                 onPressed: () async {
                   final address = (await receiver.getNewAddress()).address;
                   final res = await payJoinLibrary.buildPjUri(
-                      0.00008328, await address.toQrUri());
+                      0.0083285, await address.toQrUri());
                   setState(() {
                     pjUri = res;
                     displayText = res;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,7 @@ class _PayJoinState extends State<PayJoin> {
   String displayText = "";
   String pjUri = "";
   late PartiallySignedTransaction senderPsbt;
-  late String receiverPsbt;
+  late String receiverPsbtBase64;
   late ContextV1 contextV1;
 
   @override
@@ -226,10 +226,10 @@ class _PayJoinState extends State<PayJoin> {
                             await PartiallySignedTransaction.fromString(e)))
                         .serialize();
                   });
-                  receiverPsbt = await payJoinProposal.psbt();
+                  final receiverPsbt = await payJoinProposal.psbt();
                   debugPrint("\n Receiver response psbt: $receiverPsbt");
                   setState(() {
-                    receiverPsbt = receiverPsbt;
+                    receiverPsbtBase64 = receiverPsbt;
                   });
                 },
                 child: Text(
@@ -241,8 +241,9 @@ class _PayJoinState extends State<PayJoin> {
                 )),
             TextButton(
                 onPressed: () async {
-                  final processedReceiverResponsePsbt = await contextV1
-                      .processResponse(response: utf8.encode(receiverPsbt));
+                  final processedReceiverResponsePsbt =
+                      await contextV1.processResponse(
+                          response: utf8.encode(receiverPsbtBase64));
                   final finalizedPsbt = (await sender.signPsbt(
                       await PartiallySignedTransaction.fromString(
                           processedReceiverResponsePsbt)));

--- a/example/lib/payjoin_library.dart
+++ b/example/lib/payjoin_library.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:flutter/cupertino.dart';
 import 'package:payjoin_flutter/common.dart' as common;
 import 'package:payjoin_flutter/receive/v1.dart' as v1;
+import 'package:payjoin_flutter/receive/v2.dart';
 import 'package:payjoin_flutter/send.dart' as send;
 import 'package:payjoin_flutter/uri.dart' as pj_uri;
 
@@ -33,19 +34,42 @@ class PayJoinLibrary {
     });
     final unchecked = await v1.UncheckedProposal.fromRequest(
         body: body.toList(), query: '', headers: headers);
-    final provisionalProposal = await handleUnckedProposal(unchecked, isOwned);
+    final provisionalProposal =
+        await handleUncheckedProposal(unchecked, isOwned);
     return provisionalProposal;
   }
 
-  Future<v1.ProvisionalProposal> handleUnckedProposal(
+  Future<v1.ProvisionalProposal> handleUncheckedProposal(
       v1.UncheckedProposal uncheckedProposal,
       Future<bool> Function(Uint8List) isOwned) async {
-    // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-    var _ = await uncheckedProposal.extractTxToScheduleBroadcast();
-    final inputsOwned = await uncheckedProposal.checkBroadcastSuitability(
-        canBroadcast: (e) async {
-      return true;
-    });
+    // A consumer wallet has some manual interaction to initiate a payjoin, it
+    //  is not a server that can receive a lot of requests without the user
+    //  being aware of it. Therefore we say a consumer wallet app is an
+    //  interactive receiver and an automatic payment processor is
+    //  non-interactive.
+    //
+    //  The way to check a proposal for these cases are different:
+    //   - For an interactive receiver, you can just call
+    //      `assumeInteractiveReceiver` as used here in the example code.
+    //   - For a non-interactive receiver, you would extract the original tx
+    //      with `extractTxToScheduleBroadcast` and check if it can be
+    //      broadcasted in `checkBroadcastSuitability`. This way, if the sender
+    //      doesn't complete the payjoin, you can still broadcast the original
+    //      tx and get your funds. This protects against sender maliciousness of
+    //      probing your utxo set amongst other things.
+
+    final inputsOwned = await uncheckedProposal.assumeInteractiveReceiver();
+    /*
+      // Non-interactive receiver example code:
+      final originalTx = await uncheckedProposal.extractTxToScheduleBroadcast();
+      final inputsOwned = await uncheckedProposal.checkBroadcastSuitability(
+          canBroadcast: (e) async {
+        // Here you would check if the original tx is a valid tx that pays you 
+        //  and that can be broadcasted.
+        return true;
+      });
+    */
+
     // Receive Check 2: receiver can't sign for proposal inputs
     final mixedInputScripts =
         await inputsOwned.checkInputsNotOwned(isOwned: isOwned);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,8 +37,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: bdk-payjoin-integration-fix
-      resolved-ref: ea7f666e1358bccb3fe6a99883d454bfcacf37f4
+      ref: main
+      resolved-ref: "821fe90d20c955e3cdfbfecea3b91fe24885552a"
       url: "https://github.com/LtbLightning/bdk-flutter"
     source: git
     version: "0.31.2-dev.2"
@@ -422,11 +422,9 @@ packages:
   payjoin_flutter:
     dependency: "direct main"
     description:
-      path: "."
-      ref: main
-      resolved-ref: c3d300fcf942cf0e5d42a093af416ac70777a69a
-      url: "https://github.com/LtbLightning/payjoin-flutter"
-    source: git
+      path: ".."
+      relative: true
+    source: path
     version: "0.13.0"
   platform:
     dependency: transitive

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,8 +37,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.31.2-dev.2"
-      resolved-ref: "18649436038282f379e9a4679656bcd084434ddd"
+      ref: bdk-payjoin-integration-fix
+      resolved-ref: ea7f666e1358bccb3fe6a99883d454bfcacf37f4
       url: "https://github.com/LtbLightning/bdk-flutter"
     source: git
     version: "0.31.2-dev.2"
@@ -422,9 +422,11 @@ packages:
   payjoin_flutter:
     dependency: "direct main"
     description:
-      path: ".."
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: c3d300fcf942cf0e5d42a093af416ac70777a69a
+      url: "https://github.com/LtbLightning/payjoin-flutter"
+    source: git
     version: "0.13.0"
   platform:
     dependency: transitive

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: payjoin_flutter_example
 description: "Demonstrates how to use the payjoin plugin."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.3 <4.0.0'
+  sdk: ">=3.2.3 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -36,7 +36,9 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
-    path: ../
+    git:
+      url: https://github.com/LtbLightning/payjoin-flutter
+      ref: main
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -45,8 +47,7 @@ dependencies:
   bdk_flutter:
     git:
       url: https://github.com/LtbLightning/bdk-flutter
-      ref: v0.31.2-dev.2
-
+      ref: bdk-payjoin-integration-fix
 
   google_fonts: ^6.2.1
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,9 +36,7 @@ dependencies:
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
-    git:
-      url: https://github.com/LtbLightning/payjoin-flutter
-      ref: main
+    path: ../
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -47,7 +45,7 @@ dependencies:
   bdk_flutter:
     git:
       url: https://github.com/LtbLightning/bdk-flutter
-      ref: bdk-payjoin-integration-fix
+      ref: main
 
   google_fonts: ^6.2.1
 

--- a/lib/receive/v1.dart
+++ b/lib/receive/v1.dart
@@ -169,6 +169,8 @@ class ProvisionalProposal extends receive.ProvisionalProposal {
       return super.tryPreservingPrivacy(candidateInputs: candidateInputs);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
+    } catch (e) {
+      throw e;
     }
   }
 


### PR DESCRIPTION
This PR, except for some other very small improvements, mainly separates the logic that has to be done on the receiver's side from the logic needed to be done on the sender's side. Before, the response of the receiver was done in the same step as processing that response with the sender's wallet, now there is one step where the receiver creates and signs its response psbt and then the last step is the sender processing the response, signing it and broadcasting it. With this separation it is easier to understand for someone looking at the example to implement it correctly in its own app.