### PR TITLE
make create function of SessionInitializer static

### DIFF
--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -11,7 +11,7 @@ import '../uri.dart';
 class SessionInitializer extends FfiSessionInitializer {
   SessionInitializer._({required super.field0});
 
-  Future<SessionInitializer> create(
+  static Future<SessionInitializer> create(
       {required Url directory,
       required OhttpKeys ohttpKeys,
       required String address,


### PR DESCRIPTION
Currently it is not possible to create a `SessionInitializer` instance because it only has a private constructor and its `create` function is not static, so it can not be called. This PR makes it static so it can be called on the class to create an instance of it.