### PR TITLE
Return ffi wrappers + bug fix

### DIFF
--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -297,7 +297,7 @@ class PayjoinProposal extends FfiV2PayjoinProposal {
     try {
       final res = await FfiV2PayjoinProposal.extractV2Req(ptr: this);
       final request =
-          Request(await Url.fromString(res.$1.$1.toString()), res.$1.$2);
+          Request(await Url.fromString(res.$1.$1.asString()), res.$1.$2);
       return (request, ClientResponse._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -196,7 +196,7 @@ class OutputsUnknown extends FfiV2OutputsUnknown {
 
   /// Find which outputs belong to the receiver
   @override
-  Future<FfiV2ProvisionalProposal> identifyReceiverOutputs(
+  Future<ProvisionalProposal> identifyReceiverOutputs(
       {required FutureOr<bool> Function(Uint8List p1) isReceiverOutput,
       hint}) async {
     try {
@@ -258,7 +258,7 @@ class ProvisionalProposal extends FfiV2ProvisionalProposal {
   }
 
   @override
-  Future<FfiV2PayjoinProposal> finalizeProposal(
+  Future<PayjoinProposal> finalizeProposal(
       {required FutureOr<String> Function(String p1) processPsbt,
       BigInt? minFeerateSatPerVb,
       hint}) async {

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -61,10 +61,11 @@ class RequestBuilder extends FfiRequestBuilder {
   }
 
   @override
-  Future<FfiRequestBuilder> alwaysDisableOutputSubstitution(
+  Future<RequestBuilder> alwaysDisableOutputSubstitution(
       {required bool disable, hBigInt}) async {
     try {
-      return await super.alwaysDisableOutputSubstitution(disable: disable);
+      final res = await super.alwaysDisableOutputSubstitution(disable: disable);
+      return RequestBuilder._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }


### PR DESCRIPTION
This PR solves a small bug where `toString()` is used instead of `asString()` and also returns the Ffi class wrappers instead of the Ffi classes itself.