### PR TITLE
Override ffi functions

### DIFF
--- a/example/integration_test/bdk_full_cycle_test.dart
+++ b/example/integration_test/bdk_full_cycle_test.dart
@@ -37,7 +37,7 @@ void main() {
       await sender.syncWallet();
       // Sender create a funded PSBT (not broadcast) to address with amount given in the pjUri
       debugPrint("Sender Balance: ${sender.getBalance().toString()}");
-      final uri = await pay_join_uri.Uri.fromString(
+      final uri = await pay_join_uri.Uri.fromStr(
           "${pjReceiverAddress.toQrUri()}?amount=${0.0083285}&pj=https://example.com");
       final address = uri.address();
       int amount = (((uri.amount()) ?? 0) * 100000000).toInt();
@@ -55,7 +55,7 @@ void main() {
                   maxFeeContribution: BigInt.from(10000),
                   minFeeRate: BigInt.zero,
                   clampFeeContribution: false))
-          .extractContextV1();
+          .extractV1();
       final headers = common.Headers(map: {
         'content-type': 'text/plain',
         'content-length': req.body.length.toString(),

--- a/example/integration_test/bitcoin_core_full_cycle_test.dart
+++ b/example/integration_test/bitcoin_core_full_cycle_test.dart
@@ -30,7 +30,7 @@ void main() {
       final pjUri = await payJoinLib.buildPjUri(0.0083285, pjReceiverAddress);
       // Sender create a funded PSBT (not broadcast) to address with amount given in the pjUri
       debugPrint("Sender Balance: ${(await sender.getBalance()).toString()}");
-      final uri = await pay_join_uri.Uri.fromString(pjUri);
+      final uri = await pay_join_uri.Uri.fromStr(pjUri);
       final address = await uri.address();
       final amount = await uri.amount();
       final senderPsbt =

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -145,7 +145,7 @@ class _PayJoinState extends State<PayJoin> {
                 onPressed: () async {
                   final balance = await sender.getBalance();
                   debugPrint("Sender Balance: ${balance.toString()}");
-                  final uri = await pay_join_uri.Uri.fromString(pjUri);
+                  final uri = await pay_join_uri.Uri.fromStr(pjUri);
                   final address = await uri.address();
                   int amount =
                       (((await uri.amount()) ?? 0) * 100000000).toInt();

--- a/example/lib/payjoin_library.dart
+++ b/example/lib/payjoin_library.dart
@@ -14,7 +14,7 @@ class PayJoinLibrary {
   Future<String> buildPjUri(double amount, String address, {String? pj}) async {
     try {
       final pjUri = "$address?amount=$amount&pj=${pj ?? pjUrl}";
-      await pj_uri.Uri.fromString(pjUri);
+      await pj_uri.Uri.fromStr(pjUri);
       return pjUri;
     } catch (e) {
       debugPrint(e.toString());
@@ -26,14 +26,14 @@ class PayJoinLibrary {
       String psbtBase64,
       String uriStr,
       Future<bool> Function(Uint8List) isOwned) async {
-    final uri = await pj_uri.Uri.fromString(uriStr);
+    final uri = await pj_uri.Uri.fromStr(uriStr);
     final (req, cxt) = await (await (await send.RequestBuilder.fromPsbtAndUri(
                 psbtBase64: psbtBase64, pjUri: uri.checkPjSupported()))
             .buildWithAdditionalFee(
                 maxFeeContribution: BigInt.from(10000),
                 minFeeRate: BigInt.zero,
                 clampFeeContribution: false))
-        .extractContextV1();
+        .extractV1();
     final headers = common.Headers(map: {
       'content-type': 'text/plain',
       'content-length': req.body.length.toString(),

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -314,18 +314,18 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_proces
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_public_key(struct wire_cst_ffi_active_session *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned(int64_t port_,
-                                                                                                     struct wire_cst_ffi_maybe_inputs_owned *ptr,
+                                                                                                     struct wire_cst_ffi_maybe_inputs_owned *that,
                                                                                                      const void *is_owned);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before(int64_t port_,
-                                                                                                         struct wire_cst_ffi_maybe_inputs_seen *ptr,
+                                                                                                         struct wire_cst_ffi_maybe_inputs_seen *that,
                                                                                                          const void *is_known);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts(int64_t port_,
-                                                                                                                  struct wire_cst_ffi_maybe_mixed_input_scripts *ptr);
+                                                                                                                  struct wire_cst_ffi_maybe_mixed_input_scripts *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs(int64_t port_,
-                                                                                                     struct wire_cst_ffi_outputs_unknown *ptr,
+                                                                                                     struct wire_cst_ffi_outputs_unknown *that,
                                                                                                      const void *is_receiver_output);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_proposal_is_output_substitution_disabled(int64_t port_,
@@ -351,9 +351,9 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_
                                                                                                          struct wire_cst_out_point *outpoint);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal(int64_t port_,
-                                                                                                  struct wire_cst_ffi_provisional_proposal *ptr,
+                                                                                                  struct wire_cst_ffi_provisional_proposal *that,
                                                                                                   const void *process_psbt,
-                                                                                                  uint64_t *min_feerate_sat_per_vb);
+                                                                                                  uint64_t *min_fee_rate_sat_per_vb);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_try_preserving_privacy(int64_t port_,
                                                                                                        struct wire_cst_ffi_provisional_proposal *that,
@@ -380,10 +380,10 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_p
                                                                                            struct wire_cst_ffi_client_response *ctx);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(int64_t port_,
-                                                                                                          struct wire_cst_ffi_unchecked_proposal *ptr);
+                                                                                                          struct wire_cst_ffi_unchecked_proposal *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability(int64_t port_,
-                                                                                                          struct wire_cst_ffi_unchecked_proposal *ptr,
+                                                                                                          struct wire_cst_ffi_unchecked_proposal *that,
                                                                                                           uint64_t *min_fee_rate,
                                                                                                           const void *can_broadcast);
 

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -27,9 +27,9 @@ typedef struct wire_cst_list_prim_u_8_loose {
   int32_t len;
 } wire_cst_list_prim_u_8_loose;
 
-typedef struct wire_cst_ffi_client_response {
+typedef struct wire_cst_client_response {
   uintptr_t field0;
-} wire_cst_ffi_client_response;
+} wire_cst_client_response;
 
 typedef struct wire_cst_ffi_maybe_inputs_owned {
   uintptr_t field0;
@@ -290,26 +290,26 @@ typedef struct wire_cst_record_ffi_url_list_prim_u_8_strict {
   struct wire_cst_list_prim_u_8_strict *field1;
 } wire_cst_record_ffi_url_list_prim_u_8_strict;
 
-typedef struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response {
+typedef struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
   struct wire_cst_record_ffi_url_list_prim_u_8_strict field0;
-  struct wire_cst_ffi_client_response field1;
-} wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response;
+  struct wire_cst_client_response field1;
+} wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response;
 
 void frbgen_payjoin_flutter_wire__crate__api__io__fetch_ohttp_keys(int64_t port_,
                                                                    struct wire_cst_ffi_url *ohttp_relay,
                                                                    struct wire_cst_ffi_url *payjoin_directory);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_extract_req(int64_t port_,
-                                                                                      struct wire_cst_ffi_active_session *ptr);
+                                                                                      struct wire_cst_ffi_active_session *that);
 
-WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_uri_builder(struct wire_cst_ffi_active_session *ptr);
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_uri_builder(struct wire_cst_ffi_active_session *that);
 
-WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url(struct wire_cst_ffi_active_session *ptr);
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url(struct wire_cst_ffi_active_session *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_process_res(int64_t port_,
                                                                                       struct wire_cst_ffi_active_session *that,
                                                                                       struct wire_cst_list_prim_u_8_loose *body,
-                                                                                      struct wire_cst_ffi_client_response *ctx);
+                                                                                      struct wire_cst_client_response *ctx);
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_public_key(struct wire_cst_ffi_active_session *that);
 
@@ -364,7 +364,7 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_
                                                                                                                const void *generate_script);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_extract_req(int64_t port_,
-                                                                                           struct wire_cst_ffi_session_initializer *ptr);
+                                                                                           struct wire_cst_ffi_session_initializer *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_new(int64_t port_,
                                                                                    struct wire_cst_list_prim_u_8_strict *address,
@@ -377,7 +377,7 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_n
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_process_res(int64_t port_,
                                                                                            struct wire_cst_ffi_session_initializer *that,
                                                                                            struct wire_cst_list_prim_u_8_loose *body,
-                                                                                           struct wire_cst_ffi_client_response *ctx);
+                                                                                           struct wire_cst_client_response *ctx);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(int64_t port_,
                                                                                                           struct wire_cst_ffi_unchecked_proposal *that);
@@ -414,7 +414,7 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_
                                                                                                struct wire_cst_ffi_v_2_payjoin_proposal *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req(int64_t port_,
-                                                                                               struct wire_cst_ffi_v_2_payjoin_proposal *ptr);
+                                                                                               struct wire_cst_ffi_v_2_payjoin_proposal *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_is_output_substitution_disabled(int64_t port_,
                                                                                                                 struct wire_cst_ffi_v_2_payjoin_proposal *that);
@@ -425,7 +425,7 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res(int64_t port_,
                                                                                             struct wire_cst_ffi_v_2_payjoin_proposal *that,
                                                                                             struct wire_cst_list_prim_u_8_loose *res,
-                                                                                            struct wire_cst_ffi_client_response *ohttp_context);
+                                                                                            struct wire_cst_client_response *ohttp_context);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_psbt(int64_t port_,
                                                                                      struct wire_cst_ffi_v_2_payjoin_proposal *that);
@@ -446,7 +446,7 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_propo
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal(int64_t port_,
                                                                                                       struct wire_cst_ffi_v_2_provisional_proposal *that,
                                                                                                       const void *process_psbt,
-                                                                                                      uint64_t *min_feerate_sat_per_vb);
+                                                                                                      uint64_t *min_fee_rate_sat_per_vb);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_is_output_substitution_disabled(int64_t port_,
                                                                                                                     struct wire_cst_ffi_v_2_provisional_proposal *that);
@@ -545,13 +545,11 @@ WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_as_st
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_check_pj_supported(struct wire_cst_ffi_uri *that);
 
-void frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_from_str(int64_t port_,
-                                                                    struct wire_cst_list_prim_u_8_strict *uri);
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_from_str(struct wire_cst_list_prim_u_8_strict *uri);
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_as_string(struct wire_cst_ffi_url *that);
 
-void frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_from_str(int64_t port_,
-                                                                    struct wire_cst_list_prim_u_8_strict *url);
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_from_str(struct wire_cst_list_prim_u_8_strict *url);
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_query(struct wire_cst_ffi_url *that);
 
@@ -659,11 +657,11 @@ void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_stdsyncMu
 
 void frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(const void *ptr);
 
+struct wire_cst_client_response *frbgen_payjoin_flutter_cst_new_box_autoadd_client_response(void);
+
 double *frbgen_payjoin_flutter_cst_new_box_autoadd_f_64(double value);
 
 struct wire_cst_ffi_active_session *frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_active_session(void);
-
-struct wire_cst_ffi_client_response *frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_client_response(void);
 
 struct wire_cst_ffi_context_v_1 *frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_context_v_1(void);
 
@@ -736,9 +734,9 @@ struct wire_cst_list_record_string_string *frbgen_payjoin_flutter_cst_new_list_r
 struct wire_cst_list_record_u_64_out_point *frbgen_payjoin_flutter_cst_new_list_record_u_64_out_point(int32_t len);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_client_response);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_f_64);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_active_session);
-    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_client_response);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_context_v_1);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_context_v_2);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_maybe_inputs_owned);

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -172,6 +172,11 @@ typedef struct wire_cst_list_prim_u_64_strict {
   int32_t len;
 } wire_cst_list_prim_u_64_strict;
 
+typedef struct wire_cst_ffi_request {
+  struct wire_cst_ffi_url ffi_url;
+  struct wire_cst_list_prim_u_8_strict *body;
+} wire_cst_ffi_request;
+
 typedef struct wire_cst_PayjoinError_InvalidAddress {
   struct wire_cst_list_prim_u_8_strict *message;
 } wire_cst_PayjoinError_InvalidAddress;
@@ -270,6 +275,16 @@ typedef struct wire_cst_payjoin_error {
   union PayjoinErrorKind kind;
 } wire_cst_payjoin_error;
 
+typedef struct wire_cst_record_ffi_request_ffi_context_v_1 {
+  struct wire_cst_ffi_request field0;
+  struct wire_cst_ffi_context_v_1 field1;
+} wire_cst_record_ffi_request_ffi_context_v_1;
+
+typedef struct wire_cst_record_ffi_request_ffi_context_v_2 {
+  struct wire_cst_ffi_request field0;
+  struct wire_cst_ffi_context_v_2 field1;
+} wire_cst_record_ffi_request_ffi_context_v_2;
+
 typedef struct wire_cst_record_ffi_url_list_prim_u_8_strict {
   struct wire_cst_ffi_url field0;
   struct wire_cst_list_prim_u_8_strict *field1;
@@ -279,16 +294,6 @@ typedef struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_re
   struct wire_cst_record_ffi_url_list_prim_u_8_strict field0;
   struct wire_cst_ffi_client_response field1;
 } wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response;
-
-typedef struct wire_cst_request_context_v_1 {
-  struct wire_cst_record_ffi_url_list_prim_u_8_strict request;
-  struct wire_cst_ffi_context_v_1 context_v1;
-} wire_cst_request_context_v_1;
-
-typedef struct wire_cst_request_context_v_2 {
-  struct wire_cst_record_ffi_url_list_prim_u_8_strict request;
-  struct wire_cst_ffi_context_v_2 context_v2;
-} wire_cst_request_context_v_2;
 
 void frbgen_payjoin_flutter_wire__crate__api__io__fetch_ohttp_keys(int64_t port_,
                                                                    struct wire_cst_ffi_url *ohttp_relay,
@@ -497,10 +502,10 @@ void frbgen_payjoin_flutter_wire__crate__api__send__ffi_request_builder_from_psb
                                                                                           struct wire_cst_ffi_pj_uri *pj_uri);
 
 void frbgen_payjoin_flutter_wire__crate__api__send__ffi_request_context_extract_v1(int64_t port_,
-                                                                                   struct wire_cst_ffi_request_context *ptr);
+                                                                                   struct wire_cst_ffi_request_context *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__send__ffi_request_context_extract_v2(int64_t port_,
-                                                                                   struct wire_cst_ffi_request_context *ptr,
+                                                                                   struct wire_cst_ffi_request_context *that,
                                                                                    struct wire_cst_ffi_url *ohttp_proxy_url);
 
 void frbgen_payjoin_flutter_wire__crate__api__uri__ffi_ohttp_keys_decode(int64_t port_,
@@ -553,6 +558,10 @@ WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_query
 void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal(const void *ptr);
 
 void frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal(const void *ptr);
+
+void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(const void *ptr);
+
+void frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(const void *ptr);
 
 void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv2ContextV2(const void *ptr);
 
@@ -617,10 +626,6 @@ void frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_f
 void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal(const void *ptr);
 
 void frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal(const void *ptr);
-
-void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(const void *ptr);
-
-void frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(const void *ptr);
 
 void frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1RequestBuilder(const void *ptr);
 
@@ -770,6 +775,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_list_record_string_string);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_cst_new_list_record_u_64_out_point);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv2ContextV2);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev1MaybeInputsOwned);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev1MaybeInputsSeen);
@@ -786,7 +792,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2OutputsUnknown);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2ProvisionalProposal);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal);
-    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1RequestBuilder);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1RequestContext);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffitypesOhttpKeys);
@@ -796,6 +801,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffiuriUrl);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv2ContextV2);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffireceivev1MaybeInputsOwned);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffireceivev1MaybeInputsSeen);
@@ -812,7 +818,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffireceivev2V2OutputsUnknown);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffireceivev2V2ProvisionalProposal);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal);
-    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1RequestBuilder);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1RequestContext);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffitypesOhttpKeys);

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -299,7 +299,8 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_extrac
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_uri_builder(struct wire_cst_ffi_active_session *that);
 
-WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url(struct wire_cst_ffi_active_session *that);
+void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url(int64_t port_,
+                                                                                 struct wire_cst_ffi_active_session *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_process_res(int64_t port_,
                                                                                       struct wire_cst_ffi_active_session *that,

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -172,11 +172,6 @@ typedef struct wire_cst_list_prim_u_64_strict {
   int32_t len;
 } wire_cst_list_prim_u_64_strict;
 
-typedef struct wire_cst_ffi_request {
-  struct wire_cst_ffi_url ffi_url;
-  struct wire_cst_list_prim_u_8_strict *body;
-} wire_cst_ffi_request;
-
 typedef struct wire_cst_PayjoinError_InvalidAddress {
   struct wire_cst_list_prim_u_8_strict *message;
 } wire_cst_PayjoinError_InvalidAddress;
@@ -275,25 +270,25 @@ typedef struct wire_cst_payjoin_error {
   union PayjoinErrorKind kind;
 } wire_cst_payjoin_error;
 
-typedef struct wire_cst_record_ffi_request_ffi_context_v_1 {
-  struct wire_cst_ffi_request field0;
-  struct wire_cst_ffi_context_v_1 field1;
-} wire_cst_record_ffi_request_ffi_context_v_1;
+typedef struct wire_cst_request {
+  struct wire_cst_ffi_url url;
+  struct wire_cst_list_prim_u_8_strict *body;
+} wire_cst_request;
 
-typedef struct wire_cst_record_ffi_request_ffi_context_v_2 {
-  struct wire_cst_ffi_request field0;
-  struct wire_cst_ffi_context_v_2 field1;
-} wire_cst_record_ffi_request_ffi_context_v_2;
-
-typedef struct wire_cst_record_ffi_url_list_prim_u_8_strict {
-  struct wire_cst_ffi_url field0;
-  struct wire_cst_list_prim_u_8_strict *field1;
-} wire_cst_record_ffi_url_list_prim_u_8_strict;
-
-typedef struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
-  struct wire_cst_record_ffi_url_list_prim_u_8_strict field0;
+typedef struct wire_cst_record_request_client_response {
+  struct wire_cst_request field0;
   struct wire_cst_client_response field1;
-} wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response;
+} wire_cst_record_request_client_response;
+
+typedef struct wire_cst_record_request_ffi_context_v_1 {
+  struct wire_cst_request field0;
+  struct wire_cst_ffi_context_v_1 field1;
+} wire_cst_record_request_ffi_context_v_1;
+
+typedef struct wire_cst_record_request_ffi_context_v_2 {
+  struct wire_cst_request field0;
+  struct wire_cst_ffi_context_v_2 field1;
+} wire_cst_record_request_ffi_context_v_2;
 
 void frbgen_payjoin_flutter_wire__crate__api__io__fetch_ohttp_keys(int64_t port_,
                                                                    struct wire_cst_ffi_url *ohttp_relay,

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -1,15 +1,2 @@
-import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
-import 'package:payjoin_flutter/uri.dart';
-import 'src/generated/api/send.dart';
-
 export 'src/exceptions.dart' hide mapPayjoinError, ExceptionBase;
 export 'src/generated/utils/types.dart';
-
-class Request extends FfiRequest {
-  final Url url;
-
-  Request(
-    this.url,
-    Uint8List body,
-  ) : super(ffiUrl: url, body: body);
-}

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -1,11 +1,15 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:payjoin_flutter/uri.dart';
+import 'src/generated/api/send.dart';
 
 export 'src/exceptions.dart' hide mapPayjoinError, ExceptionBase;
 export 'src/generated/utils/types.dart';
 
-class Request {
+class Request extends FfiRequest {
   final Url url;
-  final Uint8List body;
-  Request(this.url, this.body);
+
+  Request(
+    this.url,
+    Uint8List body,
+  ) : super(ffiUrl: url, body: body);
 }

--- a/lib/receive/v1.dart
+++ b/lib/receive/v1.dart
@@ -40,13 +40,14 @@ class UncheckedProposal extends FfiUncheckedProposal {
   /// Receiver MUST check that the Original PSBT from the sender can be broadcast, i.e. testmempoolaccept bitcoind rpc returns { “allowed”: true,.. } for gettransactiontocheckbroadcast() before calling this method.
   /// Do this check if you generate bitcoin uri to receive Payjoin on sender request without manual human approval, like a payment processor. Such so called “non-interactive” receivers are otherwise vulnerable to probing attacks. If a sender can make requests at will, they can learn which bitcoin the receiver owns at no cost. Broadcasting the Original PSBT after some time in the failure case makes incurs sender cost and prevents probing.
   /// Call this after checking downstream.
+  @override
   Future<MaybeInputsOwned> checkBroadcastSuitability(
       {BigInt? minFeeRate,
       required FutureOr<bool> Function(Uint8List) canBroadcast,
       hint}) async {
     try {
-      final res = await FfiUncheckedProposal.checkBroadcastSuitability(
-          minFeeRate: minFeeRate, canBroadcast: canBroadcast, ptr: this);
+      final res = await super.checkBroadcastSuitability(
+          minFeeRate: minFeeRate, canBroadcast: canBroadcast);
       return MaybeInputsOwned._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -56,10 +57,10 @@ class UncheckedProposal extends FfiUncheckedProposal {
   ///Call this method if the only way to initiate a `Payjoin` with this receiver requires manual intervention, as in most consumer wallets.
   /// So-called “non-interactive” receivers, like payment processors,
   /// that allow arbitrary requests are otherwise vulnerable to probing attacks.
+  @override
   Future<MaybeInputsOwned> assumeInteractiveReceiver() async {
     try {
-      final res =
-          await FfiUncheckedProposal.assumeInteractiveReceiver(ptr: this);
+      final res = await super.assumeInteractiveReceiver();
       return MaybeInputsOwned._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -69,11 +70,11 @@ class UncheckedProposal extends FfiUncheckedProposal {
 
 class MaybeInputsOwned extends FfiMaybeInputsOwned {
   MaybeInputsOwned._({required super.field0});
+  @override
   Future<MaybeMixedInputScripts> checkInputsNotOwned(
       {required FutureOr<bool> Function(Uint8List) isOwned}) async {
     try {
-      final res = await FfiMaybeInputsOwned.checkInputsNotOwned(
-          ptr: this, isOwned: isOwned);
+      final res = await super.checkInputsNotOwned(isOwned: isOwned);
       return MaybeMixedInputScripts._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -87,10 +88,10 @@ class MaybeMixedInputScripts extends FfiMaybeMixedInputScripts {
   /// Verify the original transaction did not have mixed input types Call this after checking downstream.
   ///
   /// Note: mixed spends do not necessarily indicate distinct wallet fingerprints. This check is intended to prevent some types of wallet fingerprinting.
+  @override
   Future<MaybeInputsSeen> checkNoMixedInputScripts() async {
     try {
-      final res =
-          await FfiMaybeMixedInputScripts.checkNoMixedInputScripts(ptr: this);
+      final res = await super.checkNoMixedInputScripts();
       return MaybeInputsSeen._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -100,11 +101,11 @@ class MaybeMixedInputScripts extends FfiMaybeMixedInputScripts {
 
 class MaybeInputsSeen extends FfiMaybeInputsSeen {
   MaybeInputsSeen._({required super.field0});
+  @override
   Future<OutputsUnknown> checkNoInputsSeenBefore(
       {required FutureOr<bool> Function(OutPoint) isKnown}) async {
     try {
-      final res = await FfiMaybeInputsSeen.checkNoInputsSeenBefore(
-          ptr: this, isKnown: isKnown);
+      final res = await super.checkNoInputsSeenBefore(isKnown: isKnown);
       return OutputsUnknown._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -114,11 +115,12 @@ class MaybeInputsSeen extends FfiMaybeInputsSeen {
 
 class OutputsUnknown extends FfiOutputsUnknown {
   OutputsUnknown._({required super.field0});
+  @override
   Future<ProvisionalProposal> identifyReceiverOutputs(
-      {required Future<bool> Function(Uint8List) isReceiverOutput}) async {
+      {required FutureOr<bool> Function(Uint8List) isReceiverOutput}) async {
     try {
-      final res = await FfiOutputsUnknown.identifyReceiverOutputs(
-          ptr: this, isReceiverOutput: isReceiverOutput);
+      final res = await super
+          .identifyReceiverOutputs(isReceiverOutput: isReceiverOutput);
       return ProvisionalProposal._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -174,14 +176,16 @@ class ProvisionalProposal extends FfiProvisionalProposal {
     }
   }
 
-  Future<PayjoinProposal> finalizeProposal(
-      {required FutureOr<String> Function(String) processPsbt,
-      BigInt? minFeeRateSatPerVb}) async {
+  @override
+  Future<PayjoinProposal> finalizeProposal({
+    required FutureOr<String> Function(String) processPsbt,
+    BigInt? minFeeRateSatPerVb,
+  }) async {
     try {
-      final res = await FfiProvisionalProposal.finalizeProposal(
-          processPsbt: processPsbt,
-          minFeerateSatPerVb: minFeeRateSatPerVb,
-          ptr: this);
+      final res = await super.finalizeProposal(
+        processPsbt: processPsbt,
+        minFeeRateSatPerVb: minFeeRateSatPerVb,
+      );
       return PayjoinProposal._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -32,22 +32,23 @@ class SessionInitializer extends FfiSessionInitializer {
     }
   }
 
-  Future<ActiveSession> processResponse(
-      {required List<int> body, required ClientResponse clientResponse}) async {
+  @override
+  Future<ActiveSession> processRes(
+      {required List<int> body, required ClientResponse ctx}) async {
     try {
-      final res = await super.processRes(body: body, ctx: clientResponse);
+      final res = await super.processRes(body: body, ctx: ctx);
       return ActiveSession._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }
   }
 
-  Future<(Request, ClientResponse)> extractRequest({hint}) async {
+  @override
+  Future<(Request, ClientResponse)> extractReq() async {
     try {
-      final res = await FfiSessionInitializer.extractReq(ptr: this);
-      final request =
-          Request(await Url.fromStr(res.$1.$1.asString()), res.$1.$2);
-      return (request, ClientResponse._(field0: res.$2.field0));
+      final res = await super.extractReq();
+      final request = Request(Url.fromStr(res.$1.$1.asString()), res.$1.$2);
+      return (request, res.$2);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }
@@ -56,21 +57,23 @@ class SessionInitializer extends FfiSessionInitializer {
 
 class ActiveSession extends FfiActiveSession {
   ActiveSession._({required super.field0});
-  Future<(Request, ClientResponse)> extractRequest({hint}) async {
+
+  @override
+  Future<(Request, ClientResponse)> extractReq() async {
     try {
-      final res = await FfiActiveSession.extractReq(ptr: this);
-      final request =
-          Request(await Url.fromStr(res.$1.$1.asString()), res.$1.$2);
-      return (request, ClientResponse._(field0: res.$2.field0));
+      final res = await super.extractReq();
+      final request = Request(Url.fromStr(res.$1.$1.asString()), res.$1.$2);
+      return (request, res.$2);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }
   }
 
-  Future<UncheckedProposal?> processResponse(
-      {required List<int> body, required ClientResponse clientResponse}) async {
+  @override
+  Future<UncheckedProposal?> processRes(
+      {required List<int> body, required ClientResponse ctx}) async {
     try {
-      final res = await super.processRes(body: body, ctx: clientResponse);
+      final res = await super.processRes(body: body, ctx: ctx);
       if (res != null) {
         return UncheckedProposal._(field0: res.field0);
       } else {
@@ -83,13 +86,15 @@ class ActiveSession extends FfiActiveSession {
 
   /// The contents of the `&pj=` query parameter including the base64url-encoded public key receiver subdirectory.
   /// This identifies a session at the payjoin directory server.
-  Future<Url> pjUrl() {
-    final res = FfiActiveSession.pjUrl(ptr: this);
+  @override
+  Url pjUrl() {
+    final res = super.pjUrl();
     return Url.fromStr(res.asString());
   }
 
+  @override
   PjUriBuilder pjUriBuilder() {
-    final res = FfiActiveSession.pjUriBuilder(ptr: this);
+    final res = super.pjUriBuilder();
     return PjUriBuilder(internal: res.internal);
   }
 }
@@ -260,11 +265,11 @@ class ProvisionalProposal extends FfiV2ProvisionalProposal {
   @override
   Future<PayjoinProposal> finalizeProposal(
       {required FutureOr<String> Function(String p1) processPsbt,
-      BigInt? minFeerateSatPerVb,
+      BigInt? minFeeRateSatPerVb,
       hint}) async {
     try {
       final res = await super.finalizeProposal(
-          processPsbt: processPsbt, minFeerateSatPerVb: minFeerateSatPerVb);
+          processPsbt: processPsbt, minFeeRateSatPerVb: minFeeRateSatPerVb);
       return PayjoinProposal._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -275,7 +280,8 @@ class ProvisionalProposal extends FfiV2ProvisionalProposal {
 class PayjoinProposal extends FfiV2PayjoinProposal {
   PayjoinProposal._({required super.field0});
 
-  Future<void> processResponse(
+  @override
+  Future<void> processRes(
       {required List<int> res, required ClientResponse ohttpContext}) {
     try {
       return super.processRes(ohttpContext: ohttpContext, res: res);
@@ -293,12 +299,12 @@ class PayjoinProposal extends FfiV2PayjoinProposal {
     }
   }
 
-  Future<(Request, ClientResponse)> extractV2Request({hint}) async {
+  @override
+  Future<(Request, ClientResponse)> extractV2Req() async {
     try {
-      final res = await FfiV2PayjoinProposal.extractV2Req(ptr: this);
-      final request =
-          Request(await Url.fromStr(res.$1.$1.asString()), res.$1.$2);
-      return (request, ClientResponse._(field0: res.$2.field0));
+      final res = await super.extractV2Req();
+      final request = Request(Url.fromStr(res.$1.$1.asString()), res.$1.$2);
+      return (request, res.$2);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }
@@ -339,8 +345,4 @@ class PayjoinProposal extends FfiV2PayjoinProposal {
       throw mapPayjoinError(e);
     }
   }
-}
-
-class ClientResponse extends FfiClientResponse {
-  ClientResponse._({required super.field0});
 }

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -48,7 +48,7 @@ class SessionInitializer extends FfiSessionInitializer {
     try {
       final res = await super.extractReq();
       final request = Request(
-        url: Url.fromStr(res.$1.url.asString()),
+        url: await Url.fromStr(res.$1.url.asString()),
         body: res.$1.body,
       );
       return (request, res.$2);
@@ -66,7 +66,7 @@ class ActiveSession extends FfiActiveSession {
     try {
       final res = await super.extractReq();
       final request = Request(
-        url: Url.fromStr(res.$1.url.asString()),
+        url: await Url.fromStr(res.$1.url.asString()),
         body: res.$1.body,
       );
       return (request, res.$2);
@@ -93,8 +93,8 @@ class ActiveSession extends FfiActiveSession {
   /// The contents of the `&pj=` query parameter including the base64url-encoded public key receiver subdirectory.
   /// This identifies a session at the payjoin directory server.
   @override
-  Url pjUrl() {
-    final res = super.pjUrl();
+  Future<Url> pjUrl() async {
+    final res = await super.pjUrl();
     return Url.fromStr(res.asString());
   }
 
@@ -310,7 +310,7 @@ class PayjoinProposal extends FfiV2PayjoinProposal {
     try {
       final res = await super.extractV2Req();
       final request = Request(
-        url: Url.fromStr(res.$1.url.asString()),
+        url: await Url.fromStr(res.$1.url.asString()),
         body: res.$1.body,
       );
       return (request, res.$2);

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -46,7 +46,7 @@ class SessionInitializer extends FfiSessionInitializer {
     try {
       final res = await FfiSessionInitializer.extractReq(ptr: this);
       final request =
-          Request(await Url.fromString(res.$1.$1.asString()), res.$1.$2);
+          Request(await Url.fromStr(res.$1.$1.asString()), res.$1.$2);
       return (request, ClientResponse._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -60,7 +60,7 @@ class ActiveSession extends FfiActiveSession {
     try {
       final res = await FfiActiveSession.extractReq(ptr: this);
       final request =
-          Request(await Url.fromString(res.$1.$1.asString()), res.$1.$2);
+          Request(await Url.fromStr(res.$1.$1.asString()), res.$1.$2);
       return (request, ClientResponse._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -85,7 +85,7 @@ class ActiveSession extends FfiActiveSession {
   /// This identifies a session at the payjoin directory server.
   Future<Url> pjUrl() {
     final res = FfiActiveSession.pjUrl(ptr: this);
-    return Url.fromString(res.asString());
+    return Url.fromStr(res.asString());
   }
 
   PjUriBuilder pjUriBuilder() {
@@ -297,7 +297,7 @@ class PayjoinProposal extends FfiV2PayjoinProposal {
     try {
       final res = await FfiV2PayjoinProposal.extractV2Req(ptr: this);
       final request =
-          Request(await Url.fromString(res.$1.$1.asString()), res.$1.$2);
+          Request(await Url.fromStr(res.$1.$1.asString()), res.$1.$2);
       return (request, ClientResponse._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -47,7 +47,10 @@ class SessionInitializer extends FfiSessionInitializer {
   Future<(Request, ClientResponse)> extractReq() async {
     try {
       final res = await super.extractReq();
-      final request = Request(Url.fromStr(res.$1.$1.asString()), res.$1.$2);
+      final request = Request(
+        url: Url.fromStr(res.$1.url.asString()),
+        body: res.$1.body,
+      );
       return (request, res.$2);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -62,7 +65,10 @@ class ActiveSession extends FfiActiveSession {
   Future<(Request, ClientResponse)> extractReq() async {
     try {
       final res = await super.extractReq();
-      final request = Request(Url.fromStr(res.$1.$1.asString()), res.$1.$2);
+      final request = Request(
+        url: Url.fromStr(res.$1.url.asString()),
+        body: res.$1.body,
+      );
       return (request, res.$2);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -303,7 +309,10 @@ class PayjoinProposal extends FfiV2PayjoinProposal {
   Future<(Request, ClientResponse)> extractV2Req() async {
     try {
       final res = await super.extractV2Req();
-      final request = Request(Url.fromStr(res.$1.$1.asString()), res.$1.$2);
+      final request = Request(
+        url: Url.fromStr(res.$1.url.asString()),
+        body: res.$1.body,
+      );
       return (request, res.$2);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -81,8 +81,8 @@ class RequestContext extends FfiRequestContext {
     try {
       final res = await super.extractV1();
       final request = common.Request(
-        Url.fromStr((res.$1.ffiUrl.asString())),
-        res.$1.body,
+        url: Url.fromStr((res.$1.url.asString())),
+        body: res.$1.body,
       );
       return (request, ContextV1._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
@@ -99,8 +99,8 @@ class RequestContext extends FfiRequestContext {
         ohttpProxyUrl: ohttpProxyUrl,
       );
       final request = common.Request(
-        Url.fromStr((res.$1.ffiUrl.asString())),
-        res.$1.body,
+        url: Url.fromStr((res.$1.url.asString())),
+        body: res.$1.body,
       );
       return (request, ContextV2._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -81,7 +81,9 @@ class RequestContext extends FfiRequestContext {
     try {
       final res = await super.extractV1();
       final request = common.Request(
-          await Url.fromStr((res.$1.ffiUrl.asString())), res.$1.body);
+        Url.fromStr((res.$1.ffiUrl.asString())),
+        res.$1.body,
+      );
       return (request, ContextV1._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -97,7 +99,9 @@ class RequestContext extends FfiRequestContext {
         ohttpProxyUrl: ohttpProxyUrl,
       );
       final request = common.Request(
-          await Url.fromStr((res.$1.ffiUrl.asString())), res.$1.body);
+        Url.fromStr((res.$1.ffiUrl.asString())),
+        res.$1.body,
+      );
       return (request, ContextV2._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -81,7 +81,7 @@ class RequestContext extends FfiRequestContext {
     try {
       final res = await super.extractV1();
       final request = common.Request(
-        url: Url.fromStr((res.$1.url.asString())),
+        url: await Url.fromStr((res.$1.url.asString())),
         body: res.$1.body,
       );
       return (request, ContextV1._(field0: res.$2.field0));
@@ -99,7 +99,7 @@ class RequestContext extends FfiRequestContext {
         ohttpProxyUrl: ohttpProxyUrl,
       );
       final request = common.Request(
-        url: Url.fromStr((res.$1.url.asString())),
+        url: await Url.fromStr((res.$1.url.asString())),
         body: res.$1.body,
       );
       return (request, ContextV2._(field0: res.$2.field0));

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -4,6 +4,7 @@ import 'package:payjoin_flutter/uri.dart';
 
 import 'common.dart' as common;
 import 'src/generated/api/send.dart';
+import 'src/generated/api/uri.dart';
 import 'src/generated/utils/error.dart' as error;
 
 class RequestBuilder extends FfiRequestBuilder {
@@ -75,25 +76,29 @@ class RequestBuilder extends FfiRequestBuilder {
 class RequestContext extends FfiRequestContext {
   RequestContext._({required super.field0});
 
-  Future<(common.Request, ContextV1)> extractContextV1() async {
+  @override
+  Future<(common.Request, ContextV1)> extractV1() async {
     try {
-      final res = await FfiRequestContext.extractV1(ptr: this);
+      final res = await super.extractV1();
       final request = common.Request(
-          await Url.fromString((res.request.$1.asString())), res.request.$2);
-      return (request, ContextV1._(field0: res.contextV1.field0));
+          await Url.fromStr((res.$1.ffiUrl.asString())), res.$1.body);
+      return (request, ContextV1._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }
   }
 
-  Future<(common.Request, ContextV2)> extractContextV2(
-      Url ohttpProxyUrl) async {
+  @override
+  Future<(common.Request, ContextV2)> extractV2({
+    required FfiUrl ohttpProxyUrl,
+  }) async {
     try {
-      final res = await FfiRequestContext.extractV2(
-          ohttpProxyUrl: ohttpProxyUrl, ptr: this);
+      final res = await super.extractV2(
+        ohttpProxyUrl: ohttpProxyUrl,
+      );
       final request = common.Request(
-          await Url.fromString((res.request.$1.asString())), res.request.$2);
-      return (request, ContextV2._(field0: res.contextV2.field0));
+          await Url.fromStr((res.$1.ffiUrl.asString())), res.$1.body);
+      return (request, ContextV2._(field0: res.$2.field0));
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }

--- a/lib/src/generated/api/receive.dart
+++ b/lib/src/generated/api/receive.dart
@@ -30,7 +30,8 @@ class FfiActiveSession {
         that: this,
       );
 
-  FfiUrl pjUrl() => core.instance.api.crateApiReceiveFfiActiveSessionPjUrl(
+  Future<FfiUrl> pjUrl() =>
+      core.instance.api.crateApiReceiveFfiActiveSessionPjUrl(
         that: this,
       );
 

--- a/lib/src/generated/api/receive.dart
+++ b/lib/src/generated/api/receive.dart
@@ -77,11 +77,10 @@ class FfiMaybeInputsOwned {
     required this.field0,
   });
 
-  static Future<FfiMaybeMixedInputScripts> checkInputsNotOwned(
-          {required FfiMaybeInputsOwned ptr,
-          required FutureOr<bool> Function(Uint8List) isOwned}) =>
+  Future<FfiMaybeMixedInputScripts> checkInputsNotOwned(
+          {required FutureOr<bool> Function(Uint8List) isOwned}) =>
       core.instance.api.crateApiReceiveFfiMaybeInputsOwnedCheckInputsNotOwned(
-          ptr: ptr, isOwned: isOwned);
+          that: this, isOwned: isOwned);
 
   @override
   int get hashCode => field0.hashCode;
@@ -101,12 +100,11 @@ class FfiMaybeInputsSeen {
     required this.field0,
   });
 
-  static Future<FfiOutputsUnknown> checkNoInputsSeenBefore(
-          {required FfiMaybeInputsSeen ptr,
-          required FutureOr<bool> Function(OutPoint) isKnown}) =>
+  Future<FfiOutputsUnknown> checkNoInputsSeenBefore(
+          {required FutureOr<bool> Function(OutPoint) isKnown}) =>
       core.instance.api
           .crateApiReceiveFfiMaybeInputsSeenCheckNoInputsSeenBefore(
-              ptr: ptr, isKnown: isKnown);
+              that: this, isKnown: isKnown);
 
   @override
   int get hashCode => field0.hashCode;
@@ -126,11 +124,10 @@ class FfiMaybeMixedInputScripts {
     required this.field0,
   });
 
-  static Future<FfiMaybeInputsSeen> checkNoMixedInputScripts(
-          {required FfiMaybeMixedInputScripts ptr}) =>
-      core.instance.api
+  Future<FfiMaybeInputsSeen> checkNoMixedInputScripts() => core.instance.api
           .crateApiReceiveFfiMaybeMixedInputScriptsCheckNoMixedInputScripts(
-              ptr: ptr);
+        that: this,
+      );
 
   @override
   int get hashCode => field0.hashCode;
@@ -150,11 +147,10 @@ class FfiOutputsUnknown {
     required this.field0,
   });
 
-  static Future<FfiProvisionalProposal> identifyReceiverOutputs(
-          {required FfiOutputsUnknown ptr,
-          required FutureOr<bool> Function(Uint8List) isReceiverOutput}) =>
+  Future<FfiProvisionalProposal> identifyReceiverOutputs(
+          {required FutureOr<bool> Function(Uint8List) isReceiverOutput}) =>
       core.instance.api.crateApiReceiveFfiOutputsUnknownIdentifyReceiverOutputs(
-          ptr: ptr, isReceiverOutput: isReceiverOutput);
+          that: this, isReceiverOutput: isReceiverOutput);
 
   @override
   int get hashCode => field0.hashCode;
@@ -224,14 +220,13 @@ class FfiProvisionalProposal {
           .crateApiReceiveFfiProvisionalProposalContributeWitnessInput(
               that: this, txo: txo, outpoint: outpoint);
 
-  static Future<FfiPayjoinProposal> finalizeProposal(
-          {required FfiProvisionalProposal ptr,
-          required FutureOr<String> Function(String) processPsbt,
-          BigInt? minFeerateSatPerVb}) =>
+  Future<FfiPayjoinProposal> finalizeProposal(
+          {required FutureOr<String> Function(String) processPsbt,
+          BigInt? minFeeRateSatPerVb}) =>
       core.instance.api.crateApiReceiveFfiProvisionalProposalFinalizeProposal(
-          ptr: ptr,
+          that: this,
           processPsbt: processPsbt,
-          minFeerateSatPerVb: minFeerateSatPerVb);
+          minFeeRateSatPerVb: minFeeRateSatPerVb);
 
   Future<OutPoint> tryPreservingPrivacy(
           {required Map<BigInt, OutPoint> candidateInputs}) =>
@@ -310,11 +305,10 @@ class FfiUncheckedProposal {
   /// Call this method if the only way to initiate a Payjoin with this receiver requires manual intervention, as in most consumer wallets.
   ///
   /// So-called “non-interactive” receivers, like payment processors, that allow arbitrary requests are otherwise vulnerable to probing attacks. Those receivers call get_transaction_to_check_broadcast() and attest_tested_and_scheduled_broadcast() after making those checks downstream.
-  static Future<FfiMaybeInputsOwned> assumeInteractiveReceiver(
-          {required FfiUncheckedProposal ptr}) =>
-      core.instance.api
+  Future<FfiMaybeInputsOwned> assumeInteractiveReceiver() => core.instance.api
           .crateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiver(
-              ptr: ptr);
+        that: this,
+      );
 
   /// Call after checking that the Original PSBT can be broadcast.
   ///
@@ -323,13 +317,12 @@ class FfiUncheckedProposal {
   /// Do this check if you generate bitcoin uri to receive Payjoin on sender request without manual human approval, like a payment processor. Such so called “non-interactive” receivers are otherwise vulnerable to probing attacks. If a sender can make requests at will, they can learn which bitcoin the receiver owns at no cost. Broadcasting the Original PSBT after some time in the failure case makes incurs sender cost and prevents probing.
   ///
   /// Call this after checking downstream.
-  static Future<FfiMaybeInputsOwned> checkBroadcastSuitability(
-          {required FfiUncheckedProposal ptr,
-          BigInt? minFeeRate,
+  Future<FfiMaybeInputsOwned> checkBroadcastSuitability(
+          {BigInt? minFeeRate,
           required FutureOr<bool> Function(Uint8List) canBroadcast}) =>
       core.instance.api
           .crateApiReceiveFfiUncheckedProposalCheckBroadcastSuitability(
-              ptr: ptr, minFeeRate: minFeeRate, canBroadcast: canBroadcast);
+              that: this, minFeeRate: minFeeRate, canBroadcast: canBroadcast);
 
   /// The Sender’s Original PSBT
   Future<Uint8List> extractTxToScheduleBroadcast() => core.instance.api

--- a/lib/src/generated/api/receive.dart
+++ b/lib/src/generated/api/receive.dart
@@ -11,7 +11,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'uri.dart';
 
 // These functions are ignored because they are not marked as `pub`: `_finalize_proposal`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 class FfiActiveSession {
   final ActiveSession field0;
@@ -20,18 +20,22 @@ class FfiActiveSession {
     required this.field0,
   });
 
-  static Future<((FfiUrl, Uint8List), FfiClientResponse)> extractReq(
-          {required FfiActiveSession ptr}) =>
-      core.instance.api.crateApiReceiveFfiActiveSessionExtractReq(ptr: ptr);
+  Future<((FfiUrl, Uint8List), ClientResponse)> extractReq() =>
+      core.instance.api.crateApiReceiveFfiActiveSessionExtractReq(
+        that: this,
+      );
 
-  static FfiPjUriBuilder pjUriBuilder({required FfiActiveSession ptr}) =>
-      core.instance.api.crateApiReceiveFfiActiveSessionPjUriBuilder(ptr: ptr);
+  FfiPjUriBuilder pjUriBuilder() =>
+      core.instance.api.crateApiReceiveFfiActiveSessionPjUriBuilder(
+        that: this,
+      );
 
-  static FfiUrl pjUrl({required FfiActiveSession ptr}) =>
-      core.instance.api.crateApiReceiveFfiActiveSessionPjUrl(ptr: ptr);
+  FfiUrl pjUrl() => core.instance.api.crateApiReceiveFfiActiveSessionPjUrl(
+        that: this,
+      );
 
   Future<FfiV2UncheckedProposal?> processRes(
-          {required List<int> body, required FfiClientResponse ctx}) =>
+          {required List<int> body, required ClientResponse ctx}) =>
       core.instance.api.crateApiReceiveFfiActiveSessionProcessRes(
           that: this, body: body, ctx: ctx);
 
@@ -48,24 +52,6 @@ class FfiActiveSession {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is FfiActiveSession &&
-          runtimeType == other.runtimeType &&
-          field0 == other.field0;
-}
-
-class FfiClientResponse {
-  final MutexOptionClientResponse field0;
-
-  const FfiClientResponse({
-    required this.field0,
-  });
-
-  @override
-  int get hashCode => field0.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is FfiClientResponse &&
           runtimeType == other.runtimeType &&
           field0 == other.field0;
 }
@@ -258,10 +244,10 @@ class FfiSessionInitializer {
     required this.field0,
   });
 
-  static Future<((FfiUrl, Uint8List), FfiClientResponse)> extractReq(
-          {required FfiSessionInitializer ptr}) =>
-      core.instance.api
-          .crateApiReceiveFfiSessionInitializerExtractReq(ptr: ptr);
+  Future<((FfiUrl, Uint8List), ClientResponse)> extractReq() =>
+      core.instance.api.crateApiReceiveFfiSessionInitializerExtractReq(
+        that: this,
+      );
 
   // HINT: Make it `#[frb(sync)]` to let it become the default constructor of Dart class.
   static Future<FfiSessionInitializer> newInstance(
@@ -280,7 +266,7 @@ class FfiSessionInitializer {
           ohttpRelay: ohttpRelay);
 
   Future<FfiActiveSession> processRes(
-          {required List<int> body, required FfiClientResponse ctx}) =>
+          {required List<int> body, required ClientResponse ctx}) =>
       core.instance.api.crateApiReceiveFfiSessionInitializerProcessRes(
           that: this, body: body, ctx: ctx);
 
@@ -465,10 +451,10 @@ class FfiV2PayjoinProposal {
         that: this,
       );
 
-  static Future<((FfiUrl, Uint8List), FfiClientResponse)> extractV2Req(
-          {required FfiV2PayjoinProposal ptr}) =>
-      core.instance.api
-          .crateApiReceiveFfiV2PayjoinProposalExtractV2Req(ptr: ptr);
+  Future<((FfiUrl, Uint8List), ClientResponse)> extractV2Req() =>
+      core.instance.api.crateApiReceiveFfiV2PayjoinProposalExtractV2Req(
+        that: this,
+      );
 
   Future<bool> isOutputSubstitutionDisabled() => core.instance.api
           .crateApiReceiveFfiV2PayjoinProposalIsOutputSubstitutionDisabled(
@@ -481,7 +467,7 @@ class FfiV2PayjoinProposal {
       );
 
   Future<void> processRes(
-          {required List<int> res, required FfiClientResponse ohttpContext}) =>
+          {required List<int> res, required ClientResponse ohttpContext}) =>
       core.instance.api.crateApiReceiveFfiV2PayjoinProposalProcessRes(
           that: this, res: res, ohttpContext: ohttpContext);
 
@@ -527,11 +513,11 @@ class FfiV2ProvisionalProposal {
 
   Future<FfiV2PayjoinProposal> finalizeProposal(
           {required FutureOr<String> Function(String) processPsbt,
-          BigInt? minFeerateSatPerVb}) =>
+          BigInt? minFeeRateSatPerVb}) =>
       core.instance.api.crateApiReceiveFfiV2ProvisionalProposalFinalizeProposal(
           that: this,
           processPsbt: processPsbt,
-          minFeerateSatPerVb: minFeerateSatPerVb);
+          minFeeRateSatPerVb: minFeeRateSatPerVb);
 
   Future<bool> isOutputSubstitutionDisabled() => core.instance.api
           .crateApiReceiveFfiV2ProvisionalProposalIsOutputSubstitutionDisabled(

--- a/lib/src/generated/api/receive.dart
+++ b/lib/src/generated/api/receive.dart
@@ -20,7 +20,7 @@ class FfiActiveSession {
     required this.field0,
   });
 
-  Future<((FfiUrl, Uint8List), ClientResponse)> extractReq() =>
+  Future<(Request, ClientResponse)> extractReq() =>
       core.instance.api.crateApiReceiveFfiActiveSessionExtractReq(
         that: this,
       );
@@ -244,7 +244,7 @@ class FfiSessionInitializer {
     required this.field0,
   });
 
-  Future<((FfiUrl, Uint8List), ClientResponse)> extractReq() =>
+  Future<(Request, ClientResponse)> extractReq() =>
       core.instance.api.crateApiReceiveFfiSessionInitializerExtractReq(
         that: this,
       );
@@ -451,7 +451,7 @@ class FfiV2PayjoinProposal {
         that: this,
       );
 
-  Future<((FfiUrl, Uint8List), ClientResponse)> extractV2Req() =>
+  Future<(Request, ClientResponse)> extractV2Req() =>
       core.instance.api.crateApiReceiveFfiV2PayjoinProposalExtractV2Req(
         that: this,
       );

--- a/lib/src/generated/api/send.dart
+++ b/lib/src/generated/api/send.dart
@@ -9,10 +9,11 @@ import '../utils/error.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'uri.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These types are ignored because they are not used by any `pub` functions: `FfiRequestContextV1`, `FfiRequestContextV2`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 class FfiContextV1 {
-  final ContextV1 field0;
+  final ArcContextV1 field0;
 
   const FfiContextV1({
     required this.field0,
@@ -53,6 +54,27 @@ class FfiContextV2 {
       other is FfiContextV2 &&
           runtimeType == other.runtimeType &&
           field0 == other.field0;
+}
+
+class FfiRequest {
+  final FfiUrl ffiUrl;
+  final Uint8List body;
+
+  const FfiRequest({
+    required this.ffiUrl,
+    required this.body,
+  });
+
+  @override
+  int get hashCode => ffiUrl.hashCode ^ body.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FfiRequest &&
+          runtimeType == other.runtimeType &&
+          ffiUrl == other.ffiUrl &&
+          body == other.body;
 }
 
 class FfiRequestBuilder {
@@ -112,13 +134,15 @@ class FfiRequestContext {
     required this.field0,
   });
 
-  static Future<RequestContextV1> extractV1({required FfiRequestContext ptr}) =>
-      core.instance.api.crateApiSendFfiRequestContextExtractV1(ptr: ptr);
+  Future<(FfiRequest, FfiContextV1)> extractV1() =>
+      core.instance.api.crateApiSendFfiRequestContextExtractV1(
+        that: this,
+      );
 
-  static Future<RequestContextV2> extractV2(
-          {required FfiRequestContext ptr, required FfiUrl ohttpProxyUrl}) =>
+  Future<(FfiRequest, FfiContextV2)> extractV2(
+          {required FfiUrl ohttpProxyUrl}) =>
       core.instance.api.crateApiSendFfiRequestContextExtractV2(
-          ptr: ptr, ohttpProxyUrl: ohttpProxyUrl);
+          that: this, ohttpProxyUrl: ohttpProxyUrl);
 
   @override
   int get hashCode => field0.hashCode;
@@ -129,46 +153,4 @@ class FfiRequestContext {
       other is FfiRequestContext &&
           runtimeType == other.runtimeType &&
           field0 == other.field0;
-}
-
-class RequestContextV1 {
-  final (FfiUrl, Uint8List) request;
-  final FfiContextV1 contextV1;
-
-  const RequestContextV1({
-    required this.request,
-    required this.contextV1,
-  });
-
-  @override
-  int get hashCode => request.hashCode ^ contextV1.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RequestContextV1 &&
-          runtimeType == other.runtimeType &&
-          request == other.request &&
-          contextV1 == other.contextV1;
-}
-
-class RequestContextV2 {
-  final (FfiUrl, Uint8List) request;
-  final FfiContextV2 contextV2;
-
-  const RequestContextV2({
-    required this.request,
-    required this.contextV2,
-  });
-
-  @override
-  int get hashCode => request.hashCode ^ contextV2.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RequestContextV2 &&
-          runtimeType == other.runtimeType &&
-          request == other.request &&
-          contextV2 == other.contextV2;
 }

--- a/lib/src/generated/api/send.dart
+++ b/lib/src/generated/api/send.dart
@@ -6,11 +6,12 @@
 import '../frb_generated.dart';
 import '../lib.dart';
 import '../utils/error.dart';
+import '../utils/types.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'uri.dart';
 
 // These types are ignored because they are not used by any `pub` functions: `FfiRequestContextV1`, `FfiRequestContextV2`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 class FfiContextV1 {
   final ArcContextV1 field0;
@@ -54,27 +55,6 @@ class FfiContextV2 {
       other is FfiContextV2 &&
           runtimeType == other.runtimeType &&
           field0 == other.field0;
-}
-
-class FfiRequest {
-  final FfiUrl ffiUrl;
-  final Uint8List body;
-
-  const FfiRequest({
-    required this.ffiUrl,
-    required this.body,
-  });
-
-  @override
-  int get hashCode => ffiUrl.hashCode ^ body.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is FfiRequest &&
-          runtimeType == other.runtimeType &&
-          ffiUrl == other.ffiUrl &&
-          body == other.body;
 }
 
 class FfiRequestBuilder {
@@ -134,13 +114,12 @@ class FfiRequestContext {
     required this.field0,
   });
 
-  Future<(FfiRequest, FfiContextV1)> extractV1() =>
+  Future<(Request, FfiContextV1)> extractV1() =>
       core.instance.api.crateApiSendFfiRequestContextExtractV1(
         that: this,
       );
 
-  Future<(FfiRequest, FfiContextV2)> extractV2(
-          {required FfiUrl ohttpProxyUrl}) =>
+  Future<(Request, FfiContextV2)> extractV2({required FfiUrl ohttpProxyUrl}) =>
       core.instance.api.crateApiSendFfiRequestContextExtractV2(
           that: this, ohttpProxyUrl: ohttpProxyUrl);
 

--- a/lib/src/generated/api/uri.dart
+++ b/lib/src/generated/api/uri.dart
@@ -78,7 +78,7 @@ class FfiPjUriBuilder {
         that: this,
       );
 
-  static Future<FfiPjUriBuilder> _create(
+  static Future<FfiPjUriBuilder> create(
           {required String address,
           required FfiUrl pj,
           FfiOhttpKeys? ohttpKeys,

--- a/lib/src/generated/api/uri.dart
+++ b/lib/src/generated/api/uri.dart
@@ -134,7 +134,7 @@ class FfiUri {
         that: this,
       );
 
-  static Future<FfiUri> fromStr({required String uri}) =>
+  static FfiUri fromStr({required String uri}) =>
       core.instance.api.crateApiUriFfiUriFromStr(uri: uri);
 
   @override
@@ -159,7 +159,7 @@ class FfiUrl {
         that: this,
       );
 
-  static Future<FfiUrl> fromStr({required String url}) =>
+  static FfiUrl fromStr({required String url}) =>
       core.instance.api.crateApiUriFfiUrlFromStr(url: url);
 
   String? query() => core.instance.api.crateApiUriFfiUrlQuery(

--- a/lib/src/generated/api/uri.dart
+++ b/lib/src/generated/api/uri.dart
@@ -78,7 +78,7 @@ class FfiPjUriBuilder {
         that: this,
       );
 
-  static Future<FfiPjUriBuilder> create(
+  static Future<FfiPjUriBuilder> _create(
           {required String address,
           required FfiUrl pj,
           FfiOhttpKeys? ohttpKeys,

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -94,21 +94,21 @@ abstract class coreApi extends BaseApi {
 
   Future<FfiMaybeMixedInputScripts>
       crateApiReceiveFfiMaybeInputsOwnedCheckInputsNotOwned(
-          {required FfiMaybeInputsOwned ptr,
+          {required FfiMaybeInputsOwned that,
           required FutureOr<bool> Function(Uint8List) isOwned});
 
   Future<FfiOutputsUnknown>
       crateApiReceiveFfiMaybeInputsSeenCheckNoInputsSeenBefore(
-          {required FfiMaybeInputsSeen ptr,
+          {required FfiMaybeInputsSeen that,
           required FutureOr<bool> Function(OutPoint) isKnown});
 
   Future<FfiMaybeInputsSeen>
       crateApiReceiveFfiMaybeMixedInputScriptsCheckNoMixedInputScripts(
-          {required FfiMaybeMixedInputScripts ptr});
+          {required FfiMaybeMixedInputScripts that});
 
   Future<FfiProvisionalProposal>
       crateApiReceiveFfiOutputsUnknownIdentifyReceiverOutputs(
-          {required FfiOutputsUnknown ptr,
+          {required FfiOutputsUnknown that,
           required FutureOr<bool> Function(Uint8List) isReceiverOutput});
 
   Future<bool> crateApiReceiveFfiPayjoinProposalIsOutputSubstitutionDisabled(
@@ -135,9 +135,9 @@ abstract class coreApi extends BaseApi {
 
   Future<FfiPayjoinProposal>
       crateApiReceiveFfiProvisionalProposalFinalizeProposal(
-          {required FfiProvisionalProposal ptr,
+          {required FfiProvisionalProposal that,
           required FutureOr<String> Function(String) processPsbt,
-          BigInt? minFeerateSatPerVb});
+          BigInt? minFeeRateSatPerVb});
 
   Future<OutPoint> crateApiReceiveFfiProvisionalProposalTryPreservingPrivacy(
       {required FfiProvisionalProposal that,
@@ -166,11 +166,11 @@ abstract class coreApi extends BaseApi {
 
   Future<FfiMaybeInputsOwned>
       crateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiver(
-          {required FfiUncheckedProposal ptr});
+          {required FfiUncheckedProposal that});
 
   Future<FfiMaybeInputsOwned>
       crateApiReceiveFfiUncheckedProposalCheckBroadcastSuitability(
-          {required FfiUncheckedProposal ptr,
+          {required FfiUncheckedProposal that,
           BigInt? minFeeRate,
           required FutureOr<bool> Function(Uint8List) canBroadcast});
 
@@ -733,11 +733,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   @override
   Future<FfiMaybeMixedInputScripts>
       crateApiReceiveFfiMaybeInputsOwnedCheckInputsNotOwned(
-          {required FfiMaybeInputsOwned ptr,
+          {required FfiMaybeInputsOwned that,
           required FutureOr<bool> Function(Uint8List) isOwned}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_maybe_inputs_owned(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_maybe_inputs_owned(that);
         var arg1 =
             cst_encode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
                 isOwned);
@@ -751,7 +751,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiMaybeInputsOwnedCheckInputsNotOwnedConstMeta,
-      argValues: [ptr, isOwned],
+      argValues: [that, isOwned],
       apiImpl: this,
     ));
   }
@@ -760,17 +760,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiMaybeInputsOwnedCheckInputsNotOwnedConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_maybe_inputs_owned_check_inputs_not_owned",
-            argNames: ["ptr", "isOwned"],
+            argNames: ["that", "isOwned"],
           );
 
   @override
   Future<FfiOutputsUnknown>
       crateApiReceiveFfiMaybeInputsSeenCheckNoInputsSeenBefore(
-          {required FfiMaybeInputsSeen ptr,
+          {required FfiMaybeInputsSeen that,
           required FutureOr<bool> Function(OutPoint) isKnown}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_maybe_inputs_seen(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_maybe_inputs_seen(that);
         var arg1 =
             cst_encode_DartFn_Inputs_out_point_Output_bool_AnyhowException(
                 isKnown);
@@ -784,7 +784,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiMaybeInputsSeenCheckNoInputsSeenBeforeConstMeta,
-      argValues: [ptr, isKnown],
+      argValues: [that, isKnown],
       apiImpl: this,
     ));
   }
@@ -793,16 +793,16 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiMaybeInputsSeenCheckNoInputsSeenBeforeConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_maybe_inputs_seen_check_no_inputs_seen_before",
-            argNames: ["ptr", "isKnown"],
+            argNames: ["that", "isKnown"],
           );
 
   @override
   Future<FfiMaybeInputsSeen>
       crateApiReceiveFfiMaybeMixedInputScriptsCheckNoMixedInputScripts(
-          {required FfiMaybeMixedInputScripts ptr}) {
+          {required FfiMaybeMixedInputScripts that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_maybe_mixed_input_scripts(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_maybe_mixed_input_scripts(that);
         return wire
             .wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts(
                 port_, arg0);
@@ -813,7 +813,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiMaybeMixedInputScriptsCheckNoMixedInputScriptsConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -823,17 +823,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           const TaskConstMeta(
             debugName:
                 "ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts",
-            argNames: ["ptr"],
+            argNames: ["that"],
           );
 
   @override
   Future<FfiProvisionalProposal>
       crateApiReceiveFfiOutputsUnknownIdentifyReceiverOutputs(
-          {required FfiOutputsUnknown ptr,
+          {required FfiOutputsUnknown that,
           required FutureOr<bool> Function(Uint8List) isReceiverOutput}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_outputs_unknown(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_outputs_unknown(that);
         var arg1 =
             cst_encode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
                 isReceiverOutput);
@@ -847,7 +847,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiOutputsUnknownIdentifyReceiverOutputsConstMeta,
-      argValues: [ptr, isReceiverOutput],
+      argValues: [that, isReceiverOutput],
       apiImpl: this,
     ));
   }
@@ -856,7 +856,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiOutputsUnknownIdentifyReceiverOutputsConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_outputs_unknown_identify_receiver_outputs",
-            argNames: ["ptr", "isReceiverOutput"],
+            argNames: ["that", "isReceiverOutput"],
           );
 
   @override
@@ -1031,16 +1031,16 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   @override
   Future<FfiPayjoinProposal>
       crateApiReceiveFfiProvisionalProposalFinalizeProposal(
-          {required FfiProvisionalProposal ptr,
+          {required FfiProvisionalProposal that,
           required FutureOr<String> Function(String) processPsbt,
-          BigInt? minFeerateSatPerVb}) {
+          BigInt? minFeeRateSatPerVb}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_provisional_proposal(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_provisional_proposal(that);
         var arg1 =
             cst_encode_DartFn_Inputs_String_Output_String_AnyhowException(
                 processPsbt);
-        var arg2 = cst_encode_opt_box_autoadd_u_64(minFeerateSatPerVb);
+        var arg2 = cst_encode_opt_box_autoadd_u_64(minFeeRateSatPerVb);
         return wire
             .wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal(
                 port_, arg0, arg1, arg2);
@@ -1051,7 +1051,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiProvisionalProposalFinalizeProposalConstMeta,
-      argValues: [ptr, processPsbt, minFeerateSatPerVb],
+      argValues: [that, processPsbt, minFeeRateSatPerVb],
       apiImpl: this,
     ));
   }
@@ -1060,7 +1060,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiProvisionalProposalFinalizeProposalConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_provisional_proposal_finalize_proposal",
-            argNames: ["ptr", "processPsbt", "minFeerateSatPerVb"],
+            argNames: ["that", "processPsbt", "minFeeRateSatPerVb"],
           );
 
   @override
@@ -1236,10 +1236,10 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   @override
   Future<FfiMaybeInputsOwned>
       crateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiver(
-          {required FfiUncheckedProposal ptr}) {
+          {required FfiUncheckedProposal that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_unchecked_proposal(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_unchecked_proposal(that);
         return wire
             .wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(
                 port_, arg0);
@@ -1250,7 +1250,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiverConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -1259,18 +1259,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiverConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_unchecked_proposal_assume_interactive_receiver",
-            argNames: ["ptr"],
+            argNames: ["that"],
           );
 
   @override
   Future<FfiMaybeInputsOwned>
       crateApiReceiveFfiUncheckedProposalCheckBroadcastSuitability(
-          {required FfiUncheckedProposal ptr,
+          {required FfiUncheckedProposal that,
           BigInt? minFeeRate,
           required FutureOr<bool> Function(Uint8List) canBroadcast}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_unchecked_proposal(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_unchecked_proposal(that);
         var arg1 = cst_encode_opt_box_autoadd_u_64(minFeeRate);
         var arg2 =
             cst_encode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
@@ -1285,7 +1285,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiUncheckedProposalCheckBroadcastSuitabilityConstMeta,
-      argValues: [ptr, minFeeRate, canBroadcast],
+      argValues: [that, minFeeRate, canBroadcast],
       apiImpl: this,
     ));
   }
@@ -1294,7 +1294,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiUncheckedProposalCheckBroadcastSuitabilityConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_unchecked_proposal_check_broadcast_suitability",
-            argNames: ["ptr", "minFeeRate", "canBroadcast"],
+            argNames: ["that", "minFeeRate", "canBroadcast"],
           );
 
   @override

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -75,9 +75,8 @@ abstract class coreApi extends BaseApi {
   Future<FfiOhttpKeys> crateApiIoFetchOhttpKeys(
       {required FfiUrl ohttpRelay, required FfiUrl payjoinDirectory});
 
-  Future<((FfiUrl, Uint8List), ClientResponse)>
-      crateApiReceiveFfiActiveSessionExtractReq(
-          {required FfiActiveSession that});
+  Future<(Request, ClientResponse)> crateApiReceiveFfiActiveSessionExtractReq(
+      {required FfiActiveSession that});
 
   FfiPjUriBuilder crateApiReceiveFfiActiveSessionPjUriBuilder(
       {required FfiActiveSession that});
@@ -147,7 +146,7 @@ abstract class coreApi extends BaseApi {
       {required FfiProvisionalProposal that,
       required FutureOr<Uint8List> Function() generateScript});
 
-  Future<((FfiUrl, Uint8List), ClientResponse)>
+  Future<(Request, ClientResponse)>
       crateApiReceiveFfiSessionInitializerExtractReq(
           {required FfiSessionInitializer that});
 
@@ -205,7 +204,7 @@ abstract class coreApi extends BaseApi {
   Future<String> crateApiReceiveFfiV2PayjoinProposalExtractV1Req(
       {required FfiV2PayjoinProposal that});
 
-  Future<((FfiUrl, Uint8List), ClientResponse)>
+  Future<(Request, ClientResponse)>
       crateApiReceiveFfiV2PayjoinProposalExtractV2Req(
           {required FfiV2PayjoinProposal that});
 
@@ -295,10 +294,10 @@ abstract class coreApi extends BaseApi {
   Future<FfiRequestBuilder> crateApiSendFfiRequestBuilderFromPsbtAndUri(
       {required String psbtBase64, required FfiPjUri pjUri});
 
-  Future<(FfiRequest, FfiContextV1)> crateApiSendFfiRequestContextExtractV1(
+  Future<(Request, FfiContextV1)> crateApiSendFfiRequestContextExtractV1(
       {required FfiRequestContext that});
 
-  Future<(FfiRequest, FfiContextV2)> crateApiSendFfiRequestContextExtractV2(
+  Future<(Request, FfiContextV2)> crateApiSendFfiRequestContextExtractV2(
       {required FfiRequestContext that, required FfiUrl ohttpProxyUrl});
 
   Future<FfiOhttpKeys> crateApiUriFfiOhttpKeysDecode(
@@ -601,9 +600,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<((FfiUrl, Uint8List), ClientResponse)>
-      crateApiReceiveFfiActiveSessionExtractReq(
-          {required FfiActiveSession that}) {
+  Future<(Request, ClientResponse)> crateApiReceiveFfiActiveSessionExtractReq(
+      {required FfiActiveSession that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_ffi_active_session(that);
@@ -611,8 +609,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
             port_, arg0);
       },
       codec: DcoCodec(
-        decodeSuccessData:
-            dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response,
+        decodeSuccessData: dco_decode_record_request_client_response,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiReceiveFfiActiveSessionExtractReqConstMeta,
@@ -1128,7 +1125,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           );
 
   @override
-  Future<((FfiUrl, Uint8List), ClientResponse)>
+  Future<(Request, ClientResponse)>
       crateApiReceiveFfiSessionInitializerExtractReq(
           {required FfiSessionInitializer that}) {
     return handler.executeNormal(NormalTask(
@@ -1139,8 +1136,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
                 port_, arg0);
       },
       codec: DcoCodec(
-        decodeSuccessData:
-            dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response,
+        decodeSuccessData: dco_decode_record_request_client_response,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiReceiveFfiSessionInitializerExtractReqConstMeta,
@@ -1515,7 +1511,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<((FfiUrl, Uint8List), ClientResponse)>
+  Future<(Request, ClientResponse)>
       crateApiReceiveFfiV2PayjoinProposalExtractV2Req(
           {required FfiV2PayjoinProposal that}) {
     return handler.executeNormal(NormalTask(
@@ -1526,8 +1522,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
                 port_, arg0);
       },
       codec: DcoCodec(
-        decodeSuccessData:
-            dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response,
+        decodeSuccessData: dco_decode_record_request_client_response,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiReceiveFfiV2PayjoinProposalExtractV2ReqConstMeta,
@@ -2179,7 +2174,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<(FfiRequest, FfiContextV1)> crateApiSendFfiRequestContextExtractV1(
+  Future<(Request, FfiContextV1)> crateApiSendFfiRequestContextExtractV1(
       {required FfiRequestContext that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -2188,7 +2183,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
             port_, arg0);
       },
       codec: DcoCodec(
-        decodeSuccessData: dco_decode_record_ffi_request_ffi_context_v_1,
+        decodeSuccessData: dco_decode_record_request_ffi_context_v_1,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiSendFfiRequestContextExtractV1ConstMeta,
@@ -2204,7 +2199,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<(FfiRequest, FfiContextV2)> crateApiSendFfiRequestContextExtractV2(
+  Future<(Request, FfiContextV2)> crateApiSendFfiRequestContextExtractV2(
       {required FfiRequestContext that, required FfiUrl ohttpProxyUrl}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -2214,7 +2209,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
             port_, arg0, arg1);
       },
       codec: DcoCodec(
-        decodeSuccessData: dco_decode_record_ffi_request_ffi_context_v_2,
+        decodeSuccessData: dco_decode_record_request_ffi_context_v_2,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiSendFfiRequestContextExtractV2ConstMeta,
@@ -3607,18 +3602,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  FfiRequest dco_decode_ffi_request(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return FfiRequest(
-      ffiUrl: dco_decode_ffi_url(arr[0]),
-      body: dco_decode_list_prim_u_8_strict(arr[1]),
-    );
-  }
-
-  @protected
   FfiRequestBuilder dco_decode_ffi_request_builder(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3967,7 +3950,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  (FfiRequest, FfiContextV1) dco_decode_record_ffi_request_ffi_context_v_1(
+  (Request, ClientResponse) dco_decode_record_request_client_response(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3975,13 +3958,27 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
     return (
-      dco_decode_ffi_request(arr[0]),
+      dco_decode_request(arr[0]),
+      dco_decode_client_response(arr[1]),
+    );
+  }
+
+  @protected
+  (Request, FfiContextV1) dco_decode_record_request_ffi_context_v_1(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_request(arr[0]),
       dco_decode_ffi_context_v_1(arr[1]),
     );
   }
 
   @protected
-  (FfiRequest, FfiContextV2) dco_decode_record_ffi_request_ffi_context_v_2(
+  (Request, FfiContextV2) dco_decode_record_request_ffi_context_v_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3989,37 +3986,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
     return (
-      dco_decode_ffi_request(arr[0]),
+      dco_decode_request(arr[0]),
       dco_decode_ffi_context_v_2(arr[1]),
-    );
-  }
-
-  @protected
-  (FfiUrl, Uint8List) dco_decode_record_ffi_url_list_prim_u_8_strict(
-      dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2) {
-      throw Exception('Expected 2 elements, got ${arr.length}');
-    }
-    return (
-      dco_decode_ffi_url(arr[0]),
-      dco_decode_list_prim_u_8_strict(arr[1]),
-    );
-  }
-
-  @protected
-  ((FfiUrl, Uint8List), ClientResponse)
-      dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
-          dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2) {
-      throw Exception('Expected 2 elements, got ${arr.length}');
-    }
-    return (
-      dco_decode_record_ffi_url_list_prim_u_8_strict(arr[0]),
-      dco_decode_client_response(arr[1]),
     );
   }
 
@@ -4046,6 +4014,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     return (
       dco_decode_u_64(arr[0]),
       dco_decode_out_point(arr[1]),
+    );
+  }
+
+  @protected
+  Request dco_decode_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return Request(
+      url: dco_decode_ffi_url(arr[0]),
+      body: dco_decode_list_prim_u_8_strict(arr[1]),
     );
   }
 
@@ -4685,14 +4665,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  FfiRequest sse_decode_ffi_request(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_ffiUrl = sse_decode_ffi_url(deserializer);
-    var var_body = sse_decode_list_prim_u_8_strict(deserializer);
-    return FfiRequest(ffiUrl: var_ffiUrl, body: var_body);
-  }
-
-  @protected
   FfiRequestBuilder sse_decode_ffi_request_builder(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5034,40 +5006,29 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  (FfiRequest, FfiContextV1) sse_decode_record_ffi_request_ffi_context_v_1(
+  (Request, ClientResponse) sse_decode_record_request_client_response(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_field0 = sse_decode_ffi_request(deserializer);
+    var var_field0 = sse_decode_request(deserializer);
+    var var_field1 = sse_decode_client_response(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  (Request, FfiContextV1) sse_decode_record_request_ffi_context_v_1(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_request(deserializer);
     var var_field1 = sse_decode_ffi_context_v_1(deserializer);
     return (var_field0, var_field1);
   }
 
   @protected
-  (FfiRequest, FfiContextV2) sse_decode_record_ffi_request_ffi_context_v_2(
+  (Request, FfiContextV2) sse_decode_record_request_ffi_context_v_2(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_field0 = sse_decode_ffi_request(deserializer);
+    var var_field0 = sse_decode_request(deserializer);
     var var_field1 = sse_decode_ffi_context_v_2(deserializer);
-    return (var_field0, var_field1);
-  }
-
-  @protected
-  (FfiUrl, Uint8List) sse_decode_record_ffi_url_list_prim_u_8_strict(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_field0 = sse_decode_ffi_url(deserializer);
-    var var_field1 = sse_decode_list_prim_u_8_strict(deserializer);
-    return (var_field0, var_field1);
-  }
-
-  @protected
-  ((FfiUrl, Uint8List), ClientResponse)
-      sse_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
-          SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_field0 =
-        sse_decode_record_ffi_url_list_prim_u_8_strict(deserializer);
-    var var_field1 = sse_decode_client_response(deserializer);
     return (var_field0, var_field1);
   }
 
@@ -5087,6 +5048,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     var var_field0 = sse_decode_u_64(deserializer);
     var var_field1 = sse_decode_out_point(deserializer);
     return (var_field0, var_field1);
+  }
+
+  @protected
+  Request sse_decode_request(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_url = sse_decode_ffi_url(deserializer);
+    var var_body = sse_decode_list_prim_u_8_strict(deserializer);
+    return Request(url: var_url, body: var_body);
   }
 
   @protected
@@ -6047,13 +6016,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_ffi_request(FfiRequest self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_ffi_url(self.ffiUrl, serializer);
-    sse_encode_list_prim_u_8_strict(self.body, serializer);
-  }
-
-  @protected
   void sse_encode_ffi_request_builder(
       FfiRequestBuilder self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -6359,35 +6321,27 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_record_ffi_request_ffi_context_v_1(
-      (FfiRequest, FfiContextV1) self, SseSerializer serializer) {
+  void sse_encode_record_request_client_response(
+      (Request, ClientResponse) self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_ffi_request(self.$1, serializer);
+    sse_encode_request(self.$1, serializer);
+    sse_encode_client_response(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_record_request_ffi_context_v_1(
+      (Request, FfiContextV1) self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_request(self.$1, serializer);
     sse_encode_ffi_context_v_1(self.$2, serializer);
   }
 
   @protected
-  void sse_encode_record_ffi_request_ffi_context_v_2(
-      (FfiRequest, FfiContextV2) self, SseSerializer serializer) {
+  void sse_encode_record_request_ffi_context_v_2(
+      (Request, FfiContextV2) self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_ffi_request(self.$1, serializer);
+    sse_encode_request(self.$1, serializer);
     sse_encode_ffi_context_v_2(self.$2, serializer);
-  }
-
-  @protected
-  void sse_encode_record_ffi_url_list_prim_u_8_strict(
-      (FfiUrl, Uint8List) self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_ffi_url(self.$1, serializer);
-    sse_encode_list_prim_u_8_strict(self.$2, serializer);
-  }
-
-  @protected
-  void sse_encode_record_record_ffi_url_list_prim_u_8_strict_client_response(
-      ((FfiUrl, Uint8List), ClientResponse) self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_record_ffi_url_list_prim_u_8_strict(self.$1, serializer);
-    sse_encode_client_response(self.$2, serializer);
   }
 
   @protected
@@ -6404,6 +6358,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.$1, serializer);
     sse_encode_out_point(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_request(Request self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ffi_url(self.url, serializer);
+    sse_encode_list_prim_u_8_strict(self.body, serializer);
   }
 
   @protected

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -81,7 +81,8 @@ abstract class coreApi extends BaseApi {
   FfiPjUriBuilder crateApiReceiveFfiActiveSessionPjUriBuilder(
       {required FfiActiveSession that});
 
-  FfiUrl crateApiReceiveFfiActiveSessionPjUrl({required FfiActiveSession that});
+  Future<FfiUrl> crateApiReceiveFfiActiveSessionPjUrl(
+      {required FfiActiveSession that});
 
   Future<FfiV2UncheckedProposal?> crateApiReceiveFfiActiveSessionProcessRes(
       {required FfiActiveSession that,
@@ -650,12 +651,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  FfiUrl crateApiReceiveFfiActiveSessionPjUrl(
+  Future<FfiUrl> crateApiReceiveFfiActiveSessionPjUrl(
       {required FfiActiveSession that}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_ffi_active_session(that);
-        return wire.wire__crate__api__receive__ffi_active_session_pj_url(arg0);
+        return wire.wire__crate__api__receive__ffi_active_session_pj_url(
+            port_, arg0);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_ffi_url,

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -295,11 +295,11 @@ abstract class coreApi extends BaseApi {
   Future<FfiRequestBuilder> crateApiSendFfiRequestBuilderFromPsbtAndUri(
       {required String psbtBase64, required FfiPjUri pjUri});
 
-  Future<RequestContextV1> crateApiSendFfiRequestContextExtractV1(
-      {required FfiRequestContext ptr});
+  Future<(FfiRequest, FfiContextV1)> crateApiSendFfiRequestContextExtractV1(
+      {required FfiRequestContext that});
 
-  Future<RequestContextV2> crateApiSendFfiRequestContextExtractV2(
-      {required FfiRequestContext ptr, required FfiUrl ohttpProxyUrl});
+  Future<(FfiRequest, FfiContextV2)> crateApiSendFfiRequestContextExtractV2(
+      {required FfiRequestContext that, required FfiUrl ohttpProxyUrl});
 
   Future<FfiOhttpKeys> crateApiUriFfiOhttpKeysDecode(
       {required List<int> bytes});
@@ -354,6 +354,14 @@ abstract class coreApi extends BaseApi {
 
   CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_ArcV2PayjoinProposalPtr;
+
+  RustArcIncrementStrongCountFnType
+      get rust_arc_increment_strong_count_ArcContextV1;
+
+  RustArcDecrementStrongCountFnType
+      get rust_arc_decrement_strong_count_ArcContextV1;
+
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ArcContextV1Ptr;
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_ArcContextV2;
@@ -497,14 +505,6 @@ abstract class coreApi extends BaseApi {
 
   CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_V2UncheckedProposalPtr;
-
-  RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_ContextV1;
-
-  RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_ContextV1;
-
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ContextV1Ptr;
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_RequestBuilder;
@@ -2178,20 +2178,20 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<RequestContextV1> crateApiSendFfiRequestContextExtractV1(
-      {required FfiRequestContext ptr}) {
+  Future<(FfiRequest, FfiContextV1)> crateApiSendFfiRequestContextExtractV1(
+      {required FfiRequestContext that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_request_context(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_request_context(that);
         return wire.wire__crate__api__send__ffi_request_context_extract_v1(
             port_, arg0);
       },
       codec: DcoCodec(
-        decodeSuccessData: dco_decode_request_context_v_1,
+        decodeSuccessData: dco_decode_record_ffi_request_ffi_context_v_1,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiSendFfiRequestContextExtractV1ConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -2199,25 +2199,25 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiSendFfiRequestContextExtractV1ConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_request_context_extract_v1",
-        argNames: ["ptr"],
+        argNames: ["that"],
       );
 
   @override
-  Future<RequestContextV2> crateApiSendFfiRequestContextExtractV2(
-      {required FfiRequestContext ptr, required FfiUrl ohttpProxyUrl}) {
+  Future<(FfiRequest, FfiContextV2)> crateApiSendFfiRequestContextExtractV2(
+      {required FfiRequestContext that, required FfiUrl ohttpProxyUrl}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_request_context(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_request_context(that);
         var arg1 = cst_encode_box_autoadd_ffi_url(ohttpProxyUrl);
         return wire.wire__crate__api__send__ffi_request_context_extract_v2(
             port_, arg0, arg1);
       },
       codec: DcoCodec(
-        decodeSuccessData: dco_decode_request_context_v_2,
+        decodeSuccessData: dco_decode_record_ffi_request_ffi_context_v_2,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiSendFfiRequestContextExtractV2ConstMeta,
-      argValues: [ptr, ohttpProxyUrl],
+      argValues: [that, ohttpProxyUrl],
       apiImpl: this,
     ));
   }
@@ -2225,7 +2225,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiSendFfiRequestContextExtractV2ConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_request_context_extract_v2",
-        argNames: ["ptr", "ohttpProxyUrl"],
+        argNames: ["that", "ohttpProxyUrl"],
       );
 
   @override
@@ -2794,6 +2794,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           .rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal;
 
   RustArcIncrementStrongCountFnType
+      get rust_arc_increment_strong_count_ArcContextV1 => wire
+          .rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1;
+
+  RustArcDecrementStrongCountFnType
+      get rust_arc_decrement_strong_count_ArcContextV1 => wire
+          .rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1;
+
+  RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_ArcContextV2 => wire
           .rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv2ContextV2;
 
@@ -2922,14 +2930,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           .rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_ContextV1 => wire
-          .rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1;
-
-  RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_ContextV1 => wire
-          .rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1;
-
-  RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_RequestBuilder => wire
           .rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1RequestBuilder;
 
@@ -3054,6 +3054,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  ArcContextV1 dco_decode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return ArcContextV1Impl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
   ArcContextV2 dco_decode_RustOpaque_Arcpayjoin_ffisendv2ContextV2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3172,12 +3179,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return V2UncheckedProposalImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
-  ContextV1 dco_decode_RustOpaque_payjoin_ffisendv1ContextV1(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ContextV1Impl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -3486,7 +3487,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FfiContextV1(
-      field0: dco_decode_RustOpaque_payjoin_ffisendv1ContextV1(arr[0]),
+      field0: dco_decode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(arr[0]),
     );
   }
 
@@ -3601,6 +3602,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     return FfiProvisionalProposal(
       field0:
           dco_decode_RustOpaque_payjoin_ffireceivev1ProvisionalProposal(arr[0]),
+    );
+  }
+
+  @protected
+  FfiRequest dco_decode_ffi_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return FfiRequest(
+      ffiUrl: dco_decode_ffi_url(arr[0]),
+      body: dco_decode_list_prim_u_8_strict(arr[1]),
     );
   }
 
@@ -3953,6 +3966,34 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  (FfiRequest, FfiContextV1) dco_decode_record_ffi_request_ffi_context_v_1(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_ffi_request(arr[0]),
+      dco_decode_ffi_context_v_1(arr[1]),
+    );
+  }
+
+  @protected
+  (FfiRequest, FfiContextV2) dco_decode_record_ffi_request_ffi_context_v_2(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_ffi_request(arr[0]),
+      dco_decode_ffi_context_v_2(arr[1]),
+    );
+  }
+
+  @protected
   (FfiUrl, Uint8List) dco_decode_record_ffi_url_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -4004,30 +4045,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     return (
       dco_decode_u_64(arr[0]),
       dco_decode_out_point(arr[1]),
-    );
-  }
-
-  @protected
-  RequestContextV1 dco_decode_request_context_v_1(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return RequestContextV1(
-      request: dco_decode_record_ffi_url_list_prim_u_8_strict(arr[0]),
-      contextV1: dco_decode_ffi_context_v_1(arr[1]),
-    );
-  }
-
-  @protected
-  RequestContextV2 dco_decode_request_context_v_2(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return RequestContextV2(
-      request: dco_decode_record_ffi_url_list_prim_u_8_strict(arr[0]),
-      contextV2: dco_decode_ffi_context_v_2(arr[1]),
     );
   }
 
@@ -4109,6 +4126,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ArcV2PayjoinProposalImpl.frbInternalSseDecode(
+        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+  }
+
+  @protected
+  ArcContextV1 sse_decode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return ArcContextV1Impl.frbInternalSseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -4244,14 +4269,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return V2UncheckedProposalImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
-  }
-
-  @protected
-  ContextV1 sse_decode_RustOpaque_payjoin_ffisendv1ContextV1(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return ContextV1Impl.frbInternalSseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -4576,7 +4593,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   FfiContextV1 sse_decode_ffi_context_v_1(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_field0 =
-        sse_decode_RustOpaque_payjoin_ffisendv1ContextV1(deserializer);
+        sse_decode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(deserializer);
     return FfiContextV1(field0: var_field0);
   }
 
@@ -4665,6 +4682,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         sse_decode_RustOpaque_payjoin_ffireceivev1ProvisionalProposal(
             deserializer);
     return FfiProvisionalProposal(field0: var_field0);
+  }
+
+  @protected
+  FfiRequest sse_decode_ffi_request(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_ffiUrl = sse_decode_ffi_url(deserializer);
+    var var_body = sse_decode_list_prim_u_8_strict(deserializer);
+    return FfiRequest(ffiUrl: var_ffiUrl, body: var_body);
   }
 
   @protected
@@ -5009,6 +5034,24 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  (FfiRequest, FfiContextV1) sse_decode_record_ffi_request_ffi_context_v_1(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_ffi_request(deserializer);
+    var var_field1 = sse_decode_ffi_context_v_1(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  (FfiRequest, FfiContextV2) sse_decode_record_ffi_request_ffi_context_v_2(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_ffi_request(deserializer);
+    var var_field1 = sse_decode_ffi_context_v_2(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
   (FfiUrl, Uint8List) sse_decode_record_ffi_url_list_prim_u_8_strict(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5044,26 +5087,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     var var_field0 = sse_decode_u_64(deserializer);
     var var_field1 = sse_decode_out_point(deserializer);
     return (var_field0, var_field1);
-  }
-
-  @protected
-  RequestContextV1 sse_decode_request_context_v_1(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_request =
-        sse_decode_record_ffi_url_list_prim_u_8_strict(deserializer);
-    var var_contextV1 = sse_decode_ffi_context_v_1(deserializer);
-    return RequestContextV1(request: var_request, contextV1: var_contextV1);
-  }
-
-  @protected
-  RequestContextV2 sse_decode_request_context_v_2(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_request =
-        sse_decode_record_ffi_url_list_prim_u_8_strict(deserializer);
-    var var_contextV2 = sse_decode_ffi_context_v_2(deserializer);
-    return RequestContextV2(request: var_request, contextV2: var_contextV2);
   }
 
   @protected
@@ -5152,6 +5175,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Cst (C-struct based), see doc to use other codecs
 // ignore: invalid_use_of_internal_member
     return (raw as ArcV2PayjoinProposalImpl).frbInternalCstEncode();
+  }
+
+  @protected
+  int cst_encode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(ArcContextV1 raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+// ignore: invalid_use_of_internal_member
+    return (raw as ArcContextV1Impl).frbInternalCstEncode();
   }
 
   @protected
@@ -5279,13 +5309,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Cst (C-struct based), see doc to use other codecs
 // ignore: invalid_use_of_internal_member
     return (raw as V2UncheckedProposalImpl).frbInternalCstEncode();
-  }
-
-  @protected
-  int cst_encode_RustOpaque_payjoin_ffisendv1ContextV1(ContextV1 raw) {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-// ignore: invalid_use_of_internal_member
-    return (raw as ContextV1Impl).frbInternalCstEncode();
   }
 
   @protected
@@ -5470,6 +5493,15 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      ArcContextV1 self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+        (self as ArcContextV1Impl).frbInternalSseEncode(move: null),
+        serializer);
+  }
+
+  @protected
   void sse_encode_RustOpaque_Arcpayjoin_ffisendv2ContextV2(
       ArcContextV2 self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5611,14 +5643,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     sse_encode_usize(
         (self as V2UncheckedProposalImpl).frbInternalSseEncode(move: null),
         serializer);
-  }
-
-  @protected
-  void sse_encode_RustOpaque_payjoin_ffisendv1ContextV1(
-      ContextV1 self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-        (self as ContextV1Impl).frbInternalSseEncode(move: null), serializer);
   }
 
   @protected
@@ -5944,7 +5968,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   @protected
   void sse_encode_ffi_context_v_1(FfiContextV1 self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_RustOpaque_payjoin_ffisendv1ContextV1(self.field0, serializer);
+    sse_encode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+        self.field0, serializer);
   }
 
   @protected
@@ -6019,6 +6044,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_RustOpaque_payjoin_ffireceivev1ProvisionalProposal(
         self.field0, serializer);
+  }
+
+  @protected
+  void sse_encode_ffi_request(FfiRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ffi_url(self.ffiUrl, serializer);
+    sse_encode_list_prim_u_8_strict(self.body, serializer);
   }
 
   @protected
@@ -6327,6 +6359,22 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_record_ffi_request_ffi_context_v_1(
+      (FfiRequest, FfiContextV1) self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ffi_request(self.$1, serializer);
+    sse_encode_ffi_context_v_1(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_record_ffi_request_ffi_context_v_2(
+      (FfiRequest, FfiContextV2) self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ffi_request(self.$1, serializer);
+    sse_encode_ffi_context_v_2(self.$2, serializer);
+  }
+
+  @protected
   void sse_encode_record_ffi_url_list_prim_u_8_strict(
       (FfiUrl, Uint8List) self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -6358,22 +6406,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.$1, serializer);
     sse_encode_out_point(self.$2, serializer);
-  }
-
-  @protected
-  void sse_encode_request_context_v_1(
-      RequestContextV1 self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_record_ffi_url_list_prim_u_8_strict(self.request, serializer);
-    sse_encode_ffi_context_v_1(self.contextV1, serializer);
-  }
-
-  @protected
-  void sse_encode_request_context_v_2(
-      RequestContextV2 self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_record_ffi_url_list_prim_u_8_strict(self.request, serializer);
-    sse_encode_ffi_context_v_2(self.contextV2, serializer);
   }
 
   @protected
@@ -6434,6 +6466,26 @@ class ActiveSessionImpl extends RustOpaque implements ActiveSession {
 }
 
 @sealed
+class ArcContextV1Impl extends RustOpaque implements ArcContextV1 {
+  // Not to be used by end users
+  ArcContextV1Impl.frbInternalDcoDecode(List<dynamic> wire)
+      : super.frbInternalDcoDecode(wire, _kStaticData);
+
+  // Not to be used by end users
+  ArcContextV1Impl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
+      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+
+  static final _kStaticData = RustArcStaticData(
+    rustArcIncrementStrongCount:
+        core.instance.api.rust_arc_increment_strong_count_ArcContextV1,
+    rustArcDecrementStrongCount:
+        core.instance.api.rust_arc_decrement_strong_count_ArcContextV1,
+    rustArcDecrementStrongCountPtr:
+        core.instance.api.rust_arc_decrement_strong_count_ArcContextV1Ptr,
+  );
+}
+
+@sealed
 class ArcContextV2Impl extends RustOpaque implements ArcContextV2 {
   // Not to be used by end users
   ArcContextV2Impl.frbInternalDcoDecode(List<dynamic> wire)
@@ -6472,26 +6524,6 @@ class ArcV2PayjoinProposalImpl extends RustOpaque
         core.instance.api.rust_arc_decrement_strong_count_ArcV2PayjoinProposal,
     rustArcDecrementStrongCountPtr: core
         .instance.api.rust_arc_decrement_strong_count_ArcV2PayjoinProposalPtr,
-  );
-}
-
-@sealed
-class ContextV1Impl extends RustOpaque implements ContextV1 {
-  // Not to be used by end users
-  ContextV1Impl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
-
-  // Not to be used by end users
-  ContextV1Impl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
-
-  static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount:
-        core.instance.api.rust_arc_increment_strong_count_ContextV1,
-    rustArcDecrementStrongCount:
-        core.instance.api.rust_arc_decrement_strong_count_ContextV1,
-    rustArcDecrementStrongCountPtr:
-        core.instance.api.rust_arc_decrement_strong_count_ContextV1Ptr,
   );
 }
 

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -75,19 +75,19 @@ abstract class coreApi extends BaseApi {
   Future<FfiOhttpKeys> crateApiIoFetchOhttpKeys(
       {required FfiUrl ohttpRelay, required FfiUrl payjoinDirectory});
 
-  Future<((FfiUrl, Uint8List), FfiClientResponse)>
+  Future<((FfiUrl, Uint8List), ClientResponse)>
       crateApiReceiveFfiActiveSessionExtractReq(
-          {required FfiActiveSession ptr});
+          {required FfiActiveSession that});
 
   FfiPjUriBuilder crateApiReceiveFfiActiveSessionPjUriBuilder(
-      {required FfiActiveSession ptr});
+      {required FfiActiveSession that});
 
-  FfiUrl crateApiReceiveFfiActiveSessionPjUrl({required FfiActiveSession ptr});
+  FfiUrl crateApiReceiveFfiActiveSessionPjUrl({required FfiActiveSession that});
 
   Future<FfiV2UncheckedProposal?> crateApiReceiveFfiActiveSessionProcessRes(
       {required FfiActiveSession that,
       required List<int> body,
-      required FfiClientResponse ctx});
+      required ClientResponse ctx});
 
   String crateApiReceiveFfiActiveSessionPublicKey(
       {required FfiActiveSession that});
@@ -147,9 +147,9 @@ abstract class coreApi extends BaseApi {
       {required FfiProvisionalProposal that,
       required FutureOr<Uint8List> Function() generateScript});
 
-  Future<((FfiUrl, Uint8List), FfiClientResponse)>
+  Future<((FfiUrl, Uint8List), ClientResponse)>
       crateApiReceiveFfiSessionInitializerExtractReq(
-          {required FfiSessionInitializer ptr});
+          {required FfiSessionInitializer that});
 
   Future<FfiSessionInitializer> crateApiReceiveFfiSessionInitializerNew(
       {required String address,
@@ -162,7 +162,7 @@ abstract class coreApi extends BaseApi {
   Future<FfiActiveSession> crateApiReceiveFfiSessionInitializerProcessRes(
       {required FfiSessionInitializer that,
       required List<int> body,
-      required FfiClientResponse ctx});
+      required ClientResponse ctx});
 
   Future<FfiMaybeInputsOwned>
       crateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiver(
@@ -205,9 +205,9 @@ abstract class coreApi extends BaseApi {
   Future<String> crateApiReceiveFfiV2PayjoinProposalExtractV1Req(
       {required FfiV2PayjoinProposal that});
 
-  Future<((FfiUrl, Uint8List), FfiClientResponse)>
+  Future<((FfiUrl, Uint8List), ClientResponse)>
       crateApiReceiveFfiV2PayjoinProposalExtractV2Req(
-          {required FfiV2PayjoinProposal ptr});
+          {required FfiV2PayjoinProposal that});
 
   Future<bool> crateApiReceiveFfiV2PayjoinProposalIsOutputSubstitutionDisabled(
       {required FfiV2PayjoinProposal that});
@@ -218,7 +218,7 @@ abstract class coreApi extends BaseApi {
   Future<void> crateApiReceiveFfiV2PayjoinProposalProcessRes(
       {required FfiV2PayjoinProposal that,
       required List<int> res,
-      required FfiClientResponse ohttpContext});
+      required ClientResponse ohttpContext});
 
   Future<String> crateApiReceiveFfiV2PayjoinProposalPsbt(
       {required FfiV2PayjoinProposal that});
@@ -240,7 +240,7 @@ abstract class coreApi extends BaseApi {
       crateApiReceiveFfiV2ProvisionalProposalFinalizeProposal(
           {required FfiV2ProvisionalProposal that,
           required FutureOr<String> Function(String) processPsbt,
-          BigInt? minFeerateSatPerVb});
+          BigInt? minFeeRateSatPerVb});
 
   Future<bool>
       crateApiReceiveFfiV2ProvisionalProposalIsOutputSubstitutionDisabled(
@@ -338,11 +338,11 @@ abstract class coreApi extends BaseApi {
 
   FfiPjUri crateApiUriFfiUriCheckPjSupported({required FfiUri that});
 
-  Future<FfiUri> crateApiUriFfiUriFromStr({required String uri});
+  FfiUri crateApiUriFfiUriFromStr({required String uri});
 
   String crateApiUriFfiUrlAsString({required FfiUrl that});
 
-  Future<FfiUrl> crateApiUriFfiUrlFromStr({required String url});
+  FfiUrl crateApiUriFfiUrlFromStr({required String url});
 
   String? crateApiUriFfiUrlQuery({required FfiUrl that});
 
@@ -601,22 +601,22 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<((FfiUrl, Uint8List), FfiClientResponse)>
+  Future<((FfiUrl, Uint8List), ClientResponse)>
       crateApiReceiveFfiActiveSessionExtractReq(
-          {required FfiActiveSession ptr}) {
+          {required FfiActiveSession that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_active_session(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_active_session(that);
         return wire.wire__crate__api__receive__ffi_active_session_extract_req(
             port_, arg0);
       },
       codec: DcoCodec(
         decodeSuccessData:
-            dco_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response,
+            dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiReceiveFfiActiveSessionExtractReqConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -624,15 +624,15 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiReceiveFfiActiveSessionExtractReqConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_active_session_extract_req",
-        argNames: ["ptr"],
+        argNames: ["that"],
       );
 
   @override
   FfiPjUriBuilder crateApiReceiveFfiActiveSessionPjUriBuilder(
-      {required FfiActiveSession ptr}) {
+      {required FfiActiveSession that}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
-        var arg0 = cst_encode_box_autoadd_ffi_active_session(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_active_session(that);
         return wire
             .wire__crate__api__receive__ffi_active_session_pj_uri_builder(arg0);
       },
@@ -641,7 +641,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         decodeErrorData: null,
       ),
       constMeta: kCrateApiReceiveFfiActiveSessionPjUriBuilderConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -649,14 +649,15 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiReceiveFfiActiveSessionPjUriBuilderConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_active_session_pj_uri_builder",
-        argNames: ["ptr"],
+        argNames: ["that"],
       );
 
   @override
-  FfiUrl crateApiReceiveFfiActiveSessionPjUrl({required FfiActiveSession ptr}) {
+  FfiUrl crateApiReceiveFfiActiveSessionPjUrl(
+      {required FfiActiveSession that}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
-        var arg0 = cst_encode_box_autoadd_ffi_active_session(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_active_session(that);
         return wire.wire__crate__api__receive__ffi_active_session_pj_url(arg0);
       },
       codec: DcoCodec(
@@ -664,7 +665,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         decodeErrorData: null,
       ),
       constMeta: kCrateApiReceiveFfiActiveSessionPjUrlConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -672,19 +673,19 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiReceiveFfiActiveSessionPjUrlConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_active_session_pj_url",
-        argNames: ["ptr"],
+        argNames: ["that"],
       );
 
   @override
   Future<FfiV2UncheckedProposal?> crateApiReceiveFfiActiveSessionProcessRes(
       {required FfiActiveSession that,
       required List<int> body,
-      required FfiClientResponse ctx}) {
+      required ClientResponse ctx}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_ffi_active_session(that);
         var arg1 = cst_encode_list_prim_u_8_loose(body);
-        var arg2 = cst_encode_box_autoadd_ffi_client_response(ctx);
+        var arg2 = cst_encode_box_autoadd_client_response(ctx);
         return wire.wire__crate__api__receive__ffi_active_session_process_res(
             port_, arg0, arg1, arg2);
       },
@@ -1127,23 +1128,23 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           );
 
   @override
-  Future<((FfiUrl, Uint8List), FfiClientResponse)>
+  Future<((FfiUrl, Uint8List), ClientResponse)>
       crateApiReceiveFfiSessionInitializerExtractReq(
-          {required FfiSessionInitializer ptr}) {
+          {required FfiSessionInitializer that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_session_initializer(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_session_initializer(that);
         return wire
             .wire__crate__api__receive__ffi_session_initializer_extract_req(
                 port_, arg0);
       },
       codec: DcoCodec(
         decodeSuccessData:
-            dco_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response,
+            dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiReceiveFfiSessionInitializerExtractReqConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -1151,7 +1152,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiReceiveFfiSessionInitializerExtractReqConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_session_initializer_extract_req",
-        argNames: ["ptr"],
+        argNames: ["that"],
       );
 
   @override
@@ -1207,12 +1208,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   Future<FfiActiveSession> crateApiReceiveFfiSessionInitializerProcessRes(
       {required FfiSessionInitializer that,
       required List<int> body,
-      required FfiClientResponse ctx}) {
+      required ClientResponse ctx}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_ffi_session_initializer(that);
         var arg1 = cst_encode_list_prim_u_8_loose(body);
-        var arg2 = cst_encode_box_autoadd_ffi_client_response(ctx);
+        var arg2 = cst_encode_box_autoadd_client_response(ctx);
         return wire
             .wire__crate__api__receive__ffi_session_initializer_process_res(
                 port_, arg0, arg1, arg2);
@@ -1514,23 +1515,23 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<((FfiUrl, Uint8List), FfiClientResponse)>
+  Future<((FfiUrl, Uint8List), ClientResponse)>
       crateApiReceiveFfiV2PayjoinProposalExtractV2Req(
-          {required FfiV2PayjoinProposal ptr}) {
+          {required FfiV2PayjoinProposal that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_v_2_payjoin_proposal(ptr);
+        var arg0 = cst_encode_box_autoadd_ffi_v_2_payjoin_proposal(that);
         return wire
             .wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req(
                 port_, arg0);
       },
       codec: DcoCodec(
         decodeSuccessData:
-            dco_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response,
+            dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response,
         decodeErrorData: dco_decode_payjoin_error,
       ),
       constMeta: kCrateApiReceiveFfiV2PayjoinProposalExtractV2ReqConstMeta,
-      argValues: [ptr],
+      argValues: [that],
       apiImpl: this,
     ));
   }
@@ -1538,7 +1539,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiReceiveFfiV2PayjoinProposalExtractV2ReqConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_v_2_payjoin_proposal_extract_v2_req",
-        argNames: ["ptr"],
+        argNames: ["that"],
       );
 
   @override
@@ -1600,12 +1601,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   Future<void> crateApiReceiveFfiV2PayjoinProposalProcessRes(
       {required FfiV2PayjoinProposal that,
       required List<int> res,
-      required FfiClientResponse ohttpContext}) {
+      required ClientResponse ohttpContext}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_ffi_v_2_payjoin_proposal(that);
         var arg1 = cst_encode_list_prim_u_8_loose(res);
-        var arg2 = cst_encode_box_autoadd_ffi_client_response(ohttpContext);
+        var arg2 = cst_encode_box_autoadd_client_response(ohttpContext);
         return wire
             .wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res(
                 port_, arg0, arg1, arg2);
@@ -1748,14 +1749,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       crateApiReceiveFfiV2ProvisionalProposalFinalizeProposal(
           {required FfiV2ProvisionalProposal that,
           required FutureOr<String> Function(String) processPsbt,
-          BigInt? minFeerateSatPerVb}) {
+          BigInt? minFeeRateSatPerVb}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_ffi_v_2_provisional_proposal(that);
         var arg1 =
             cst_encode_DartFn_Inputs_String_Output_String_AnyhowException(
                 processPsbt);
-        var arg2 = cst_encode_opt_box_autoadd_u_64(minFeerateSatPerVb);
+        var arg2 = cst_encode_opt_box_autoadd_u_64(minFeeRateSatPerVb);
         return wire
             .wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal(
                 port_, arg0, arg1, arg2);
@@ -1766,7 +1767,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ),
       constMeta:
           kCrateApiReceiveFfiV2ProvisionalProposalFinalizeProposalConstMeta,
-      argValues: [that, processPsbt, minFeerateSatPerVb],
+      argValues: [that, processPsbt, minFeeRateSatPerVb],
       apiImpl: this,
     ));
   }
@@ -1775,7 +1776,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       get kCrateApiReceiveFfiV2ProvisionalProposalFinalizeProposalConstMeta =>
           const TaskConstMeta(
             debugName: "ffi_v_2_provisional_proposal_finalize_proposal",
-            argNames: ["that", "processPsbt", "minFeerateSatPerVb"],
+            argNames: ["that", "processPsbt", "minFeeRateSatPerVb"],
           );
 
   @override
@@ -2565,11 +2566,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<FfiUri> crateApiUriFfiUriFromStr({required String uri}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
+  FfiUri crateApiUriFfiUriFromStr({required String uri}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
         var arg0 = cst_encode_String(uri);
-        return wire.wire__crate__api__uri__ffi_uri_from_str(port_, arg0);
+        return wire.wire__crate__api__uri__ffi_uri_from_str(arg0);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_ffi_uri,
@@ -2609,11 +2610,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
-  Future<FfiUrl> crateApiUriFfiUrlFromStr({required String url}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
+  FfiUrl crateApiUriFfiUrlFromStr({required String url}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
         var arg0 = cst_encode_String(url);
-        return wire.wire__crate__api__uri__ffi_url_from_str(port_, arg0);
+        return wire.wire__crate__api__uri__ffi_url_from_str(arg0);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_ffi_url,
@@ -3247,6 +3248,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  ClientResponse dco_decode_box_autoadd_client_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_client_response(raw);
+  }
+
+  @protected
   double dco_decode_box_autoadd_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
@@ -3256,12 +3263,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   FfiActiveSession dco_decode_box_autoadd_ffi_active_session(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_ffi_active_session(raw);
-  }
-
-  @protected
-  FfiClientResponse dco_decode_box_autoadd_ffi_client_response(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_ffi_client_response(raw);
   }
 
   @protected
@@ -3451,6 +3452,19 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  ClientResponse dco_decode_client_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return ClientResponse(
+      field0:
+          dco_decode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
+              arr[0]),
+    );
+  }
+
+  @protected
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
@@ -3464,19 +3478,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FfiActiveSession(
       field0: dco_decode_RustOpaque_payjoin_ffireceivev2ActiveSession(arr[0]),
-    );
-  }
-
-  @protected
-  FfiClientResponse dco_decode_ffi_client_response(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return FfiClientResponse(
-      field0:
-          dco_decode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
-              arr[0]),
     );
   }
 
@@ -4008,8 +4009,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  ((FfiUrl, Uint8List), FfiClientResponse)
-      dco_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
+  ((FfiUrl, Uint8List), ClientResponse)
+      dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -4018,7 +4019,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     }
     return (
       dco_decode_record_ffi_url_list_prim_u_8_strict(arr[0]),
-      dco_decode_ffi_client_response(arr[1]),
+      dco_decode_client_response(arr[1]),
     );
   }
 
@@ -4349,6 +4350,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  ClientResponse sse_decode_box_autoadd_client_response(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_client_response(deserializer));
+  }
+
+  @protected
   double sse_decode_box_autoadd_f_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_f_64(deserializer));
@@ -4359,13 +4367,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_ffi_active_session(deserializer));
-  }
-
-  @protected
-  FfiClientResponse sse_decode_box_autoadd_ffi_client_response(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_ffi_client_response(deserializer));
   }
 
   @protected
@@ -4566,6 +4567,15 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  ClientResponse sse_decode_client_response(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 =
+        sse_decode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
+            deserializer);
+    return ClientResponse(field0: var_field0);
+  }
+
+  @protected
   double sse_decode_f_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat64();
@@ -4577,16 +4587,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     var var_field0 =
         sse_decode_RustOpaque_payjoin_ffireceivev2ActiveSession(deserializer);
     return FfiActiveSession(field0: var_field0);
-  }
-
-  @protected
-  FfiClientResponse sse_decode_ffi_client_response(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_field0 =
-        sse_decode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
-            deserializer);
-    return FfiClientResponse(field0: var_field0);
   }
 
   @protected
@@ -5061,13 +5061,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  ((FfiUrl, Uint8List), FfiClientResponse)
-      sse_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
+  ((FfiUrl, Uint8List), ClientResponse)
+      sse_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_field0 =
         sse_decode_record_ffi_url_list_prim_u_8_strict(deserializer);
-    var var_field1 = sse_decode_ffi_client_response(deserializer);
+    var var_field1 = sse_decode_client_response(deserializer);
     return (var_field0, var_field1);
   }
 
@@ -5727,6 +5727,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_client_response(
+      ClientResponse self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_client_response(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_f_64(self, serializer);
@@ -5737,13 +5744,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       FfiActiveSession self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_ffi_active_session(self, serializer);
-  }
-
-  @protected
-  void sse_encode_box_autoadd_ffi_client_response(
-      FfiClientResponse self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_ffi_client_response(self, serializer);
   }
 
   @protected
@@ -5944,6 +5944,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_client_response(
+      ClientResponse self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
+        self.field0, serializer);
+  }
+
+  @protected
   void sse_encode_f_64(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat64(self);
@@ -5954,14 +5962,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       FfiActiveSession self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_RustOpaque_payjoin_ffireceivev2ActiveSession(
-        self.field0, serializer);
-  }
-
-  @protected
-  void sse_encode_ffi_client_response(
-      FfiClientResponse self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
         self.field0, serializer);
   }
 
@@ -6383,13 +6383,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void
-      sse_encode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
-          ((FfiUrl, Uint8List), FfiClientResponse) self,
-          SseSerializer serializer) {
+  void sse_encode_record_record_ffi_url_list_prim_u_8_strict_client_response(
+      ((FfiUrl, Uint8List), ClientResponse) self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_record_ffi_url_list_prim_u_8_strict(self.$1, serializer);
-    sse_encode_ffi_client_response(self.$2, serializer);
+    sse_encode_client_response(self.$2, serializer);
   }
 
   @protected

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -267,13 +267,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   bool dco_decode_bool(dynamic raw);
 
   @protected
+  ClientResponse dco_decode_box_autoadd_client_response(dynamic raw);
+
+  @protected
   double dco_decode_box_autoadd_f_64(dynamic raw);
 
   @protected
   FfiActiveSession dco_decode_box_autoadd_ffi_active_session(dynamic raw);
-
-  @protected
-  FfiClientResponse dco_decode_box_autoadd_ffi_client_response(dynamic raw);
 
   @protected
   FfiContextV1 dco_decode_box_autoadd_ffi_context_v_1(dynamic raw);
@@ -375,13 +375,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   int dco_decode_box_autoadd_u_8(dynamic raw);
 
   @protected
+  ClientResponse dco_decode_client_response(dynamic raw);
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
   FfiActiveSession dco_decode_ffi_active_session(dynamic raw);
-
-  @protected
-  FfiClientResponse dco_decode_ffi_client_response(dynamic raw);
 
   @protected
   FfiContextV1 dco_decode_ffi_context_v_1(dynamic raw);
@@ -525,8 +525,8 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       dynamic raw);
 
   @protected
-  ((FfiUrl, Uint8List), FfiClientResponse)
-      dco_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
+  ((FfiUrl, Uint8List), ClientResponse)
+      dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
           dynamic raw);
 
   @protected
@@ -684,14 +684,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
+  ClientResponse sse_decode_box_autoadd_client_response(
+      SseDeserializer deserializer);
+
+  @protected
   double sse_decode_box_autoadd_f_64(SseDeserializer deserializer);
 
   @protected
   FfiActiveSession sse_decode_box_autoadd_ffi_active_session(
-      SseDeserializer deserializer);
-
-  @protected
-  FfiClientResponse sse_decode_box_autoadd_ffi_client_response(
       SseDeserializer deserializer);
 
   @protected
@@ -805,14 +805,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   int sse_decode_box_autoadd_u_8(SseDeserializer deserializer);
 
   @protected
+  ClientResponse sse_decode_client_response(SseDeserializer deserializer);
+
+  @protected
   double sse_decode_f_64(SseDeserializer deserializer);
 
   @protected
   FfiActiveSession sse_decode_ffi_active_session(SseDeserializer deserializer);
-
-  @protected
-  FfiClientResponse sse_decode_ffi_client_response(
-      SseDeserializer deserializer);
 
   @protected
   FfiContextV1 sse_decode_ffi_context_v_1(SseDeserializer deserializer);
@@ -974,8 +973,8 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
-  ((FfiUrl, Uint8List), FfiClientResponse)
-      sse_decode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
+  ((FfiUrl, Uint8List), ClientResponse)
+      sse_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
           SseDeserializer deserializer);
 
   @protected
@@ -1034,6 +1033,15 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_client_response> cst_encode_box_autoadd_client_response(
+      ClientResponse raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_client_response();
+    cst_api_fill_to_wire_client_response(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<ffi.Double> cst_encode_box_autoadd_f_64(double raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return wire.cst_new_box_autoadd_f_64(cst_encode_f_64(raw));
@@ -1045,15 +1053,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_ffi_active_session();
     cst_api_fill_to_wire_ffi_active_session(raw, ptr.ref);
-    return ptr;
-  }
-
-  @protected
-  ffi.Pointer<wire_cst_ffi_client_response>
-      cst_encode_box_autoadd_ffi_client_response(FfiClientResponse raw) {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    final ptr = wire.cst_new_box_autoadd_ffi_client_response();
-    cst_api_fill_to_wire_ffi_client_response(raw, ptr.ref);
     return ptr;
   }
 
@@ -1434,17 +1433,16 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_client_response(
+      ClientResponse apiObj, ffi.Pointer<wire_cst_client_response> wireObj) {
+    cst_api_fill_to_wire_client_response(apiObj, wireObj.ref);
+  }
+
+  @protected
   void cst_api_fill_to_wire_box_autoadd_ffi_active_session(
       FfiActiveSession apiObj,
       ffi.Pointer<wire_cst_ffi_active_session> wireObj) {
     cst_api_fill_to_wire_ffi_active_session(apiObj, wireObj.ref);
-  }
-
-  @protected
-  void cst_api_fill_to_wire_box_autoadd_ffi_client_response(
-      FfiClientResponse apiObj,
-      ffi.Pointer<wire_cst_ffi_client_response> wireObj) {
-    cst_api_fill_to_wire_ffi_client_response(apiObj, wireObj.ref);
   }
 
   @protected
@@ -1628,18 +1626,18 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_client_response(
+      ClientResponse apiObj, wire_cst_client_response wireObj) {
+    wireObj.field0 =
+        cst_encode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
+            apiObj.field0);
+  }
+
+  @protected
   void cst_api_fill_to_wire_ffi_active_session(
       FfiActiveSession apiObj, wire_cst_ffi_active_session wireObj) {
     wireObj.field0 =
         cst_encode_RustOpaque_payjoin_ffireceivev2ActiveSession(apiObj.field0);
-  }
-
-  @protected
-  void cst_api_fill_to_wire_ffi_client_response(
-      FfiClientResponse apiObj, wire_cst_ffi_client_response wireObj) {
-    wireObj.field0 =
-        cst_encode_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponse(
-            apiObj.field0);
   }
 
   @protected
@@ -1978,13 +1976,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  void cst_api_fill_to_wire_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
-      ((FfiUrl, Uint8List), FfiClientResponse) apiObj,
-      wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response
-          wireObj) {
+  void
+      cst_api_fill_to_wire_record_record_ffi_url_list_prim_u_8_strict_client_response(
+          ((FfiUrl, Uint8List), ClientResponse) apiObj,
+          wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response
+              wireObj) {
     cst_api_fill_to_wire_record_ffi_url_list_prim_u_8_strict(
         apiObj.$1, wireObj.field0);
-    cst_api_fill_to_wire_ffi_client_response(apiObj.$2, wireObj.field1);
+    cst_api_fill_to_wire_client_response(apiObj.$2, wireObj.field1);
   }
 
   @protected
@@ -2289,15 +2288,15 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_client_response(
+      ClientResponse self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_ffi_active_session(
       FfiActiveSession self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_box_autoadd_ffi_client_response(
-      FfiClientResponse self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_ffi_context_v_1(
@@ -2410,15 +2409,15 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_box_autoadd_u_8(int self, SseSerializer serializer);
 
   @protected
+  void sse_encode_client_response(
+      ClientResponse self, SseSerializer serializer);
+
+  @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
 
   @protected
   void sse_encode_ffi_active_session(
       FfiActiveSession self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_ffi_client_response(
-      FfiClientResponse self, SseSerializer serializer);
 
   @protected
   void sse_encode_ffi_context_v_1(FfiContextV1 self, SseSerializer serializer);
@@ -2583,10 +2582,8 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       (FfiUrl, Uint8List) self, SseSerializer serializer);
 
   @protected
-  void
-      sse_encode_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response(
-          ((FfiUrl, Uint8List), FfiClientResponse) self,
-          SseSerializer serializer);
+  void sse_encode_record_record_ffi_url_list_prim_u_8_strict_client_response(
+      ((FfiUrl, Uint8List), ClientResponse) self, SseSerializer serializer);
 
   @protected
   void sse_encode_record_string_string(
@@ -2679,11 +2676,11 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__receive__ffi_active_session_extract_req(
     int port_,
-    ffi.Pointer<wire_cst_ffi_active_session> ptr,
+    ffi.Pointer<wire_cst_ffi_active_session> that,
   ) {
     return _wire__crate__api__receive__ffi_active_session_extract_req(
       port_,
-      ptr,
+      that,
     );
   }
 
@@ -2699,10 +2696,10 @@ class coreWire implements BaseWire {
 
   WireSyncRust2DartDco
       wire__crate__api__receive__ffi_active_session_pj_uri_builder(
-    ffi.Pointer<wire_cst_ffi_active_session> ptr,
+    ffi.Pointer<wire_cst_ffi_active_session> that,
   ) {
     return _wire__crate__api__receive__ffi_active_session_pj_uri_builder(
-      ptr,
+      that,
     );
   }
 
@@ -2719,10 +2716,10 @@ class coreWire implements BaseWire {
                   ffi.Pointer<wire_cst_ffi_active_session>)>();
 
   WireSyncRust2DartDco wire__crate__api__receive__ffi_active_session_pj_url(
-    ffi.Pointer<wire_cst_ffi_active_session> ptr,
+    ffi.Pointer<wire_cst_ffi_active_session> that,
   ) {
     return _wire__crate__api__receive__ffi_active_session_pj_url(
-      ptr,
+      that,
     );
   }
 
@@ -2740,7 +2737,7 @@ class coreWire implements BaseWire {
     int port_,
     ffi.Pointer<wire_cst_ffi_active_session> that,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> body,
-    ffi.Pointer<wire_cst_ffi_client_response> ctx,
+    ffi.Pointer<wire_cst_client_response> ctx,
   ) {
     return _wire__crate__api__receive__ffi_active_session_process_res(
       port_,
@@ -2757,7 +2754,7 @@ class coreWire implements BaseWire {
                       ffi.Int64,
                       ffi.Pointer<wire_cst_ffi_active_session>,
                       ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                      ffi.Pointer<wire_cst_ffi_client_response>)>>(
+                      ffi.Pointer<wire_cst_client_response>)>>(
           'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_process_res');
   late final _wire__crate__api__receive__ffi_active_session_process_res =
       _wire__crate__api__receive__ffi_active_session_process_resPtr.asFunction<
@@ -2765,7 +2762,7 @@ class coreWire implements BaseWire {
               int,
               ffi.Pointer<wire_cst_ffi_active_session>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-              ffi.Pointer<wire_cst_ffi_client_response>)>();
+              ffi.Pointer<wire_cst_client_response>)>();
 
   WireSyncRust2DartDco wire__crate__api__receive__ffi_active_session_public_key(
     ffi.Pointer<wire_cst_ffi_active_session> that,
@@ -3121,11 +3118,11 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__receive__ffi_session_initializer_extract_req(
     int port_,
-    ffi.Pointer<wire_cst_ffi_session_initializer> ptr,
+    ffi.Pointer<wire_cst_ffi_session_initializer> that,
   ) {
     return _wire__crate__api__receive__ffi_session_initializer_extract_req(
       port_,
-      ptr,
+      that,
     );
   }
 
@@ -3187,7 +3184,7 @@ class coreWire implements BaseWire {
     int port_,
     ffi.Pointer<wire_cst_ffi_session_initializer> that,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> body,
-    ffi.Pointer<wire_cst_ffi_client_response> ctx,
+    ffi.Pointer<wire_cst_client_response> ctx,
   ) {
     return _wire__crate__api__receive__ffi_session_initializer_process_res(
       port_,
@@ -3204,7 +3201,7 @@ class coreWire implements BaseWire {
                       ffi.Int64,
                       ffi.Pointer<wire_cst_ffi_session_initializer>,
                       ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                      ffi.Pointer<wire_cst_ffi_client_response>)>>(
+                      ffi.Pointer<wire_cst_client_response>)>>(
           'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_process_res');
   late final _wire__crate__api__receive__ffi_session_initializer_process_res =
       _wire__crate__api__receive__ffi_session_initializer_process_resPtr
@@ -3213,7 +3210,7 @@ class coreWire implements BaseWire {
                   int,
                   ffi.Pointer<wire_cst_ffi_session_initializer>,
                   ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                  ffi.Pointer<wire_cst_ffi_client_response>)>();
+                  ffi.Pointer<wire_cst_client_response>)>();
 
   void
       wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(
@@ -3457,11 +3454,11 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req(
     int port_,
-    ffi.Pointer<wire_cst_ffi_v_2_payjoin_proposal> ptr,
+    ffi.Pointer<wire_cst_ffi_v_2_payjoin_proposal> that,
   ) {
     return _wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req(
       port_,
-      ptr,
+      that,
     );
   }
 
@@ -3526,7 +3523,7 @@ class coreWire implements BaseWire {
     int port_,
     ffi.Pointer<wire_cst_ffi_v_2_payjoin_proposal> that,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> res,
-    ffi.Pointer<wire_cst_ffi_client_response> ohttp_context,
+    ffi.Pointer<wire_cst_client_response> ohttp_context,
   ) {
     return _wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res(
       port_,
@@ -3543,7 +3540,7 @@ class coreWire implements BaseWire {
                       ffi.Int64,
                       ffi.Pointer<wire_cst_ffi_v_2_payjoin_proposal>,
                       ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                      ffi.Pointer<wire_cst_ffi_client_response>)>>(
+                      ffi.Pointer<wire_cst_client_response>)>>(
           'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res');
   late final _wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res =
       _wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_resPtr
@@ -3552,7 +3549,7 @@ class coreWire implements BaseWire {
                   int,
                   ffi.Pointer<wire_cst_ffi_v_2_payjoin_proposal>,
                   ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                  ffi.Pointer<wire_cst_ffi_client_response>)>();
+                  ffi.Pointer<wire_cst_client_response>)>();
 
   void wire__crate__api__receive__ffi_v_2_payjoin_proposal_psbt(
     int port_,
@@ -3666,13 +3663,13 @@ class coreWire implements BaseWire {
     int port_,
     ffi.Pointer<wire_cst_ffi_v_2_provisional_proposal> that,
     ffi.Pointer<ffi.Void> process_psbt,
-    ffi.Pointer<ffi.Uint64> min_feerate_sat_per_vb,
+    ffi.Pointer<ffi.Uint64> min_fee_rate_sat_per_vb,
   ) {
     return _wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal(
       port_,
       that,
       process_psbt,
-      min_feerate_sat_per_vb,
+      min_fee_rate_sat_per_vb,
     );
   }
 
@@ -4346,24 +4343,23 @@ class coreWire implements BaseWire {
       _wire__crate__api__uri__ffi_uri_check_pj_supportedPtr.asFunction<
           WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_uri>)>();
 
-  void wire__crate__api__uri__ffi_uri_from_str(
-    int port_,
+  WireSyncRust2DartDco wire__crate__api__uri__ffi_uri_from_str(
     ffi.Pointer<wire_cst_list_prim_u_8_strict> uri,
   ) {
     return _wire__crate__api__uri__ffi_uri_from_str(
-      port_,
       uri,
     );
   }
 
   late final _wire__crate__api__uri__ffi_uri_from_strPtr = _lookup<
           ffi.NativeFunction<
-              ffi.Void Function(
-                  ffi.Int64, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
       'frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_from_str');
   late final _wire__crate__api__uri__ffi_uri_from_str =
       _wire__crate__api__uri__ffi_uri_from_strPtr.asFunction<
-          void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
+          WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
 
   WireSyncRust2DartDco wire__crate__api__uri__ffi_url_as_string(
     ffi.Pointer<wire_cst_ffi_url> that,
@@ -4381,24 +4377,23 @@ class coreWire implements BaseWire {
       _wire__crate__api__uri__ffi_url_as_stringPtr.asFunction<
           WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_url>)>();
 
-  void wire__crate__api__uri__ffi_url_from_str(
-    int port_,
+  WireSyncRust2DartDco wire__crate__api__uri__ffi_url_from_str(
     ffi.Pointer<wire_cst_list_prim_u_8_strict> url,
   ) {
     return _wire__crate__api__uri__ffi_url_from_str(
-      port_,
       url,
     );
   }
 
   late final _wire__crate__api__uri__ffi_url_from_strPtr = _lookup<
           ffi.NativeFunction<
-              ffi.Void Function(
-                  ffi.Int64, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
       'frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_from_str');
   late final _wire__crate__api__uri__ffi_url_from_str =
       _wire__crate__api__uri__ffi_url_from_strPtr.asFunction<
-          void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
+          WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
 
   WireSyncRust2DartDco wire__crate__api__uri__ffi_url_query(
     ffi.Pointer<wire_cst_ffi_url> that,
@@ -5234,6 +5229,17 @@ class coreWire implements BaseWire {
       _rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexcoreoptionOptionohttpClientResponsePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
+  ffi.Pointer<wire_cst_client_response> cst_new_box_autoadd_client_response() {
+    return _cst_new_box_autoadd_client_response();
+  }
+
+  late final _cst_new_box_autoadd_client_responsePtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_cst_client_response> Function()>>(
+      'frbgen_payjoin_flutter_cst_new_box_autoadd_client_response');
+  late final _cst_new_box_autoadd_client_response =
+      _cst_new_box_autoadd_client_responsePtr
+          .asFunction<ffi.Pointer<wire_cst_client_response> Function()>();
+
   ffi.Pointer<ffi.Double> cst_new_box_autoadd_f_64(
     double value,
   ) {
@@ -5260,19 +5266,6 @@ class coreWire implements BaseWire {
   late final _cst_new_box_autoadd_ffi_active_session =
       _cst_new_box_autoadd_ffi_active_sessionPtr
           .asFunction<ffi.Pointer<wire_cst_ffi_active_session> Function()>();
-
-  ffi.Pointer<wire_cst_ffi_client_response>
-      cst_new_box_autoadd_ffi_client_response() {
-    return _cst_new_box_autoadd_ffi_client_response();
-  }
-
-  late final _cst_new_box_autoadd_ffi_client_responsePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<wire_cst_ffi_client_response> Function()>>(
-      'frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_client_response');
-  late final _cst_new_box_autoadd_ffi_client_response =
-      _cst_new_box_autoadd_ffi_client_responsePtr
-          .asFunction<ffi.Pointer<wire_cst_ffi_client_response> Function()>();
 
   ffi.Pointer<wire_cst_ffi_context_v_1> cst_new_box_autoadd_ffi_context_v_1() {
     return _cst_new_box_autoadd_ffi_context_v_1();
@@ -5760,7 +5753,7 @@ final class wire_cst_list_prim_u_8_loose extends ffi.Struct {
   external int len;
 }
 
-final class wire_cst_ffi_client_response extends ffi.Struct {
+final class wire_cst_client_response extends ffi.Struct {
   @ffi.UintPtr()
   external int field0;
 }
@@ -6087,9 +6080,9 @@ final class wire_cst_record_ffi_url_list_prim_u_8_strict extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field1;
 }
 
-final class wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response
+final class wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response
     extends ffi.Struct {
   external wire_cst_record_ffi_url_list_prim_u_8_strict field0;
 
-  external wire_cst_ffi_client_response field1;
+  external wire_cst_client_response field1;
 }

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -418,9 +418,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   FfiProvisionalProposal dco_decode_ffi_provisional_proposal(dynamic raw);
 
   @protected
-  FfiRequest dco_decode_ffi_request(dynamic raw);
-
-  @protected
   FfiRequestBuilder dco_decode_ffi_request_builder(dynamic raw);
 
   @protected
@@ -513,27 +510,25 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   PayjoinError dco_decode_payjoin_error(dynamic raw);
 
   @protected
-  (FfiRequest, FfiContextV1) dco_decode_record_ffi_request_ffi_context_v_1(
+  (Request, ClientResponse) dco_decode_record_request_client_response(
       dynamic raw);
 
   @protected
-  (FfiRequest, FfiContextV2) dco_decode_record_ffi_request_ffi_context_v_2(
+  (Request, FfiContextV1) dco_decode_record_request_ffi_context_v_1(
       dynamic raw);
 
   @protected
-  (FfiUrl, Uint8List) dco_decode_record_ffi_url_list_prim_u_8_strict(
+  (Request, FfiContextV2) dco_decode_record_request_ffi_context_v_2(
       dynamic raw);
-
-  @protected
-  ((FfiUrl, Uint8List), ClientResponse)
-      dco_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
-          dynamic raw);
 
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
 
   @protected
   (BigInt, OutPoint) dco_decode_record_u_64_out_point(dynamic raw);
+
+  @protected
+  Request dco_decode_request(dynamic raw);
 
   @protected
   TxOut dco_decode_tx_out(dynamic raw);
@@ -853,9 +848,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
-  FfiRequest sse_decode_ffi_request(SseDeserializer deserializer);
-
-  @protected
   FfiRequestBuilder sse_decode_ffi_request_builder(
       SseDeserializer deserializer);
 
@@ -961,21 +953,16 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   PayjoinError sse_decode_payjoin_error(SseDeserializer deserializer);
 
   @protected
-  (FfiRequest, FfiContextV1) sse_decode_record_ffi_request_ffi_context_v_1(
+  (Request, ClientResponse) sse_decode_record_request_client_response(
       SseDeserializer deserializer);
 
   @protected
-  (FfiRequest, FfiContextV2) sse_decode_record_ffi_request_ffi_context_v_2(
+  (Request, FfiContextV1) sse_decode_record_request_ffi_context_v_1(
       SseDeserializer deserializer);
 
   @protected
-  (FfiUrl, Uint8List) sse_decode_record_ffi_url_list_prim_u_8_strict(
+  (Request, FfiContextV2) sse_decode_record_request_ffi_context_v_2(
       SseDeserializer deserializer);
-
-  @protected
-  ((FfiUrl, Uint8List), ClientResponse)
-      sse_decode_record_record_ffi_url_list_prim_u_8_strict_client_response(
-          SseDeserializer deserializer);
 
   @protected
   (String, String) sse_decode_record_string_string(
@@ -984,6 +971,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   (BigInt, OutPoint) sse_decode_record_u_64_out_point(
       SseDeserializer deserializer);
+
+  @protected
+  Request sse_decode_request(SseDeserializer deserializer);
 
   @protected
   TxOut sse_decode_tx_out(SseDeserializer deserializer);
@@ -1721,13 +1711,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  void cst_api_fill_to_wire_ffi_request(
-      FfiRequest apiObj, wire_cst_ffi_request wireObj) {
-    cst_api_fill_to_wire_ffi_url(apiObj.ffiUrl, wireObj.ffi_url);
-    wireObj.body = cst_encode_list_prim_u_8_strict(apiObj.body);
-  }
-
-  @protected
   void cst_api_fill_to_wire_ffi_request_builder(
       FfiRequestBuilder apiObj, wire_cst_ffi_request_builder wireObj) {
     wireObj.field0 =
@@ -1952,38 +1935,27 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  void cst_api_fill_to_wire_record_ffi_request_ffi_context_v_1(
-      (FfiRequest, FfiContextV1) apiObj,
-      wire_cst_record_ffi_request_ffi_context_v_1 wireObj) {
-    cst_api_fill_to_wire_ffi_request(apiObj.$1, wireObj.field0);
+  void cst_api_fill_to_wire_record_request_client_response(
+      (Request, ClientResponse) apiObj,
+      wire_cst_record_request_client_response wireObj) {
+    cst_api_fill_to_wire_request(apiObj.$1, wireObj.field0);
+    cst_api_fill_to_wire_client_response(apiObj.$2, wireObj.field1);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_record_request_ffi_context_v_1(
+      (Request, FfiContextV1) apiObj,
+      wire_cst_record_request_ffi_context_v_1 wireObj) {
+    cst_api_fill_to_wire_request(apiObj.$1, wireObj.field0);
     cst_api_fill_to_wire_ffi_context_v_1(apiObj.$2, wireObj.field1);
   }
 
   @protected
-  void cst_api_fill_to_wire_record_ffi_request_ffi_context_v_2(
-      (FfiRequest, FfiContextV2) apiObj,
-      wire_cst_record_ffi_request_ffi_context_v_2 wireObj) {
-    cst_api_fill_to_wire_ffi_request(apiObj.$1, wireObj.field0);
+  void cst_api_fill_to_wire_record_request_ffi_context_v_2(
+      (Request, FfiContextV2) apiObj,
+      wire_cst_record_request_ffi_context_v_2 wireObj) {
+    cst_api_fill_to_wire_request(apiObj.$1, wireObj.field0);
     cst_api_fill_to_wire_ffi_context_v_2(apiObj.$2, wireObj.field1);
-  }
-
-  @protected
-  void cst_api_fill_to_wire_record_ffi_url_list_prim_u_8_strict(
-      (FfiUrl, Uint8List) apiObj,
-      wire_cst_record_ffi_url_list_prim_u_8_strict wireObj) {
-    cst_api_fill_to_wire_ffi_url(apiObj.$1, wireObj.field0);
-    wireObj.field1 = cst_encode_list_prim_u_8_strict(apiObj.$2);
-  }
-
-  @protected
-  void
-      cst_api_fill_to_wire_record_record_ffi_url_list_prim_u_8_strict_client_response(
-          ((FfiUrl, Uint8List), ClientResponse) apiObj,
-          wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response
-              wireObj) {
-    cst_api_fill_to_wire_record_ffi_url_list_prim_u_8_strict(
-        apiObj.$1, wireObj.field0);
-    cst_api_fill_to_wire_client_response(apiObj.$2, wireObj.field1);
   }
 
   @protected
@@ -1998,6 +1970,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       (BigInt, OutPoint) apiObj, wire_cst_record_u_64_out_point wireObj) {
     wireObj.field0 = cst_encode_u_64(apiObj.$1);
     cst_api_fill_to_wire_out_point(apiObj.$2, wireObj.field1);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_request(Request apiObj, wire_cst_request wireObj) {
+    cst_api_fill_to_wire_ffi_url(apiObj.url, wireObj.url);
+    wireObj.body = cst_encode_list_prim_u_8_strict(apiObj.body);
   }
 
   @protected
@@ -2460,9 +2438,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       FfiProvisionalProposal self, SseSerializer serializer);
 
   @protected
-  void sse_encode_ffi_request(FfiRequest self, SseSerializer serializer);
-
-  @protected
   void sse_encode_ffi_request_builder(
       FfiRequestBuilder self, SseSerializer serializer);
 
@@ -2570,20 +2545,16 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_payjoin_error(PayjoinError self, SseSerializer serializer);
 
   @protected
-  void sse_encode_record_ffi_request_ffi_context_v_1(
-      (FfiRequest, FfiContextV1) self, SseSerializer serializer);
+  void sse_encode_record_request_client_response(
+      (Request, ClientResponse) self, SseSerializer serializer);
 
   @protected
-  void sse_encode_record_ffi_request_ffi_context_v_2(
-      (FfiRequest, FfiContextV2) self, SseSerializer serializer);
+  void sse_encode_record_request_ffi_context_v_1(
+      (Request, FfiContextV1) self, SseSerializer serializer);
 
   @protected
-  void sse_encode_record_ffi_url_list_prim_u_8_strict(
-      (FfiUrl, Uint8List) self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_record_record_ffi_url_list_prim_u_8_strict_client_response(
-      ((FfiUrl, Uint8List), ClientResponse) self, SseSerializer serializer);
+  void sse_encode_record_request_ffi_context_v_2(
+      (Request, FfiContextV2) self, SseSerializer serializer);
 
   @protected
   void sse_encode_record_string_string(
@@ -2592,6 +2563,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_record_u_64_out_point(
       (BigInt, OutPoint) self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_request(Request self, SseSerializer serializer);
 
   @protected
   void sse_encode_tx_out(TxOut self, SseSerializer serializer);
@@ -5939,12 +5913,6 @@ final class wire_cst_list_prim_u_64_strict extends ffi.Struct {
   external int len;
 }
 
-final class wire_cst_ffi_request extends ffi.Struct {
-  external wire_cst_ffi_url ffi_url;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> body;
-}
-
 final class wire_cst_PayjoinError_InvalidAddress extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
 }
@@ -6062,27 +6030,26 @@ final class wire_cst_payjoin_error extends ffi.Struct {
   external PayjoinErrorKind kind;
 }
 
-final class wire_cst_record_ffi_request_ffi_context_v_1 extends ffi.Struct {
-  external wire_cst_ffi_request field0;
+final class wire_cst_request extends ffi.Struct {
+  external wire_cst_ffi_url url;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> body;
+}
+
+final class wire_cst_record_request_client_response extends ffi.Struct {
+  external wire_cst_request field0;
+
+  external wire_cst_client_response field1;
+}
+
+final class wire_cst_record_request_ffi_context_v_1 extends ffi.Struct {
+  external wire_cst_request field0;
 
   external wire_cst_ffi_context_v_1 field1;
 }
 
-final class wire_cst_record_ffi_request_ffi_context_v_2 extends ffi.Struct {
-  external wire_cst_ffi_request field0;
+final class wire_cst_record_request_ffi_context_v_2 extends ffi.Struct {
+  external wire_cst_request field0;
 
   external wire_cst_ffi_context_v_2 field1;
-}
-
-final class wire_cst_record_ffi_url_list_prim_u_8_strict extends ffi.Struct {
-  external wire_cst_ffi_url field0;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field1;
-}
-
-final class wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response
-    extends ffi.Struct {
-  external wire_cst_record_ffi_url_list_prim_u_8_strict field0;
-
-  external wire_cst_client_response field1;
 }

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -2689,23 +2689,24 @@ class coreWire implements BaseWire {
               WireSyncRust2DartDco Function(
                   ffi.Pointer<wire_cst_ffi_active_session>)>();
 
-  WireSyncRust2DartDco wire__crate__api__receive__ffi_active_session_pj_url(
+  void wire__crate__api__receive__ffi_active_session_pj_url(
+    int port_,
     ffi.Pointer<wire_cst_ffi_active_session> that,
   ) {
     return _wire__crate__api__receive__ffi_active_session_pj_url(
+      port_,
       that,
     );
   }
 
   late final _wire__crate__api__receive__ffi_active_session_pj_urlPtr = _lookup<
           ffi.NativeFunction<
-              WireSyncRust2DartDco Function(
-                  ffi.Pointer<wire_cst_ffi_active_session>)>>(
+              ffi.Void Function(
+                  ffi.Int64, ffi.Pointer<wire_cst_ffi_active_session>)>>(
       'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url');
   late final _wire__crate__api__receive__ffi_active_session_pj_url =
       _wire__crate__api__receive__ffi_active_session_pj_urlPtr.asFunction<
-          WireSyncRust2DartDco Function(
-              ffi.Pointer<wire_cst_ffi_active_session>)>();
+          void Function(int, ffi.Pointer<wire_cst_ffi_active_session>)>();
 
   void wire__crate__api__receive__ffi_active_session_process_res(
     int port_,

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -29,6 +29,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
           ._rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposalPtr;
 
   CrossPlatformFinalizerArg
+      get rust_arc_decrement_strong_count_ArcContextV1Ptr => wire
+          ._rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1Ptr;
+
+  CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_ArcContextV2Ptr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv2ContextV2Ptr;
 
@@ -91,9 +95,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_V2UncheckedProposalPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposalPtr;
-
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ContextV1Ptr =>
-      wire._rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1Ptr;
 
   CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_RequestBuilderPtr => wire
@@ -159,6 +160,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   ArcV2PayjoinProposal
       dco_decode_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal(
           dynamic raw);
+
+  @protected
+  ArcContextV1 dco_decode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(dynamic raw);
 
   @protected
   ArcContextV2 dco_decode_RustOpaque_Arcpayjoin_ffisendv2ContextV2(dynamic raw);
@@ -227,9 +231,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   V2UncheckedProposal
       dco_decode_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal(
           dynamic raw);
-
-  @protected
-  ContextV1 dco_decode_RustOpaque_payjoin_ffisendv1ContextV1(dynamic raw);
 
   @protected
   RequestBuilder dco_decode_RustOpaque_payjoin_ffisendv1RequestBuilder(
@@ -417,6 +418,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   FfiProvisionalProposal dco_decode_ffi_provisional_proposal(dynamic raw);
 
   @protected
+  FfiRequest dco_decode_ffi_request(dynamic raw);
+
+  @protected
   FfiRequestBuilder dco_decode_ffi_request_builder(dynamic raw);
 
   @protected
@@ -509,6 +513,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   PayjoinError dco_decode_payjoin_error(dynamic raw);
 
   @protected
+  (FfiRequest, FfiContextV1) dco_decode_record_ffi_request_ffi_context_v_1(
+      dynamic raw);
+
+  @protected
+  (FfiRequest, FfiContextV2) dco_decode_record_ffi_request_ffi_context_v_2(
+      dynamic raw);
+
+  @protected
   (FfiUrl, Uint8List) dco_decode_record_ffi_url_list_prim_u_8_strict(
       dynamic raw);
 
@@ -522,12 +534,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   (BigInt, OutPoint) dco_decode_record_u_64_out_point(dynamic raw);
-
-  @protected
-  RequestContextV1 dco_decode_request_context_v_1(dynamic raw);
-
-  @protected
-  RequestContextV2 dco_decode_request_context_v_2(dynamic raw);
 
   @protected
   TxOut dco_decode_tx_out(dynamic raw);
@@ -565,6 +571,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   ArcV2PayjoinProposal
       sse_decode_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal(
           SseDeserializer deserializer);
+
+  @protected
+  ArcContextV1 sse_decode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      SseDeserializer deserializer);
 
   @protected
   ArcContextV2 sse_decode_RustOpaque_Arcpayjoin_ffisendv2ContextV2(
@@ -636,10 +646,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   V2UncheckedProposal
       sse_decode_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal(
           SseDeserializer deserializer);
-
-  @protected
-  ContextV1 sse_decode_RustOpaque_payjoin_ffisendv1ContextV1(
-      SseDeserializer deserializer);
 
   @protected
   RequestBuilder sse_decode_RustOpaque_payjoin_ffisendv1RequestBuilder(
@@ -848,6 +854,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
+  FfiRequest sse_decode_ffi_request(SseDeserializer deserializer);
+
+  @protected
   FfiRequestBuilder sse_decode_ffi_request_builder(
       SseDeserializer deserializer);
 
@@ -953,6 +962,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   PayjoinError sse_decode_payjoin_error(SseDeserializer deserializer);
 
   @protected
+  (FfiRequest, FfiContextV1) sse_decode_record_ffi_request_ffi_context_v_1(
+      SseDeserializer deserializer);
+
+  @protected
+  (FfiRequest, FfiContextV2) sse_decode_record_ffi_request_ffi_context_v_2(
+      SseDeserializer deserializer);
+
+  @protected
   (FfiUrl, Uint8List) sse_decode_record_ffi_url_list_prim_u_8_strict(
       SseDeserializer deserializer);
 
@@ -968,12 +985,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   (BigInt, OutPoint) sse_decode_record_u_64_out_point(
       SseDeserializer deserializer);
-
-  @protected
-  RequestContextV1 sse_decode_request_context_v_1(SseDeserializer deserializer);
-
-  @protected
-  RequestContextV2 sse_decode_request_context_v_2(SseDeserializer deserializer);
 
   @protected
   TxOut sse_decode_tx_out(SseDeserializer deserializer);
@@ -1635,7 +1646,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void cst_api_fill_to_wire_ffi_context_v_1(
       FfiContextV1 apiObj, wire_cst_ffi_context_v_1 wireObj) {
     wireObj.field0 =
-        cst_encode_RustOpaque_payjoin_ffisendv1ContextV1(apiObj.field0);
+        cst_encode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(apiObj.field0);
   }
 
   @protected
@@ -1709,6 +1720,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
     wireObj.field0 =
         cst_encode_RustOpaque_payjoin_ffireceivev1ProvisionalProposal(
             apiObj.field0);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_ffi_request(
+      FfiRequest apiObj, wire_cst_ffi_request wireObj) {
+    cst_api_fill_to_wire_ffi_url(apiObj.ffiUrl, wireObj.ffi_url);
+    wireObj.body = cst_encode_list_prim_u_8_strict(apiObj.body);
   }
 
   @protected
@@ -1936,6 +1954,22 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_record_ffi_request_ffi_context_v_1(
+      (FfiRequest, FfiContextV1) apiObj,
+      wire_cst_record_ffi_request_ffi_context_v_1 wireObj) {
+    cst_api_fill_to_wire_ffi_request(apiObj.$1, wireObj.field0);
+    cst_api_fill_to_wire_ffi_context_v_1(apiObj.$2, wireObj.field1);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_record_ffi_request_ffi_context_v_2(
+      (FfiRequest, FfiContextV2) apiObj,
+      wire_cst_record_ffi_request_ffi_context_v_2 wireObj) {
+    cst_api_fill_to_wire_ffi_request(apiObj.$1, wireObj.field0);
+    cst_api_fill_to_wire_ffi_context_v_2(apiObj.$2, wireObj.field1);
+  }
+
+  @protected
   void cst_api_fill_to_wire_record_ffi_url_list_prim_u_8_strict(
       (FfiUrl, Uint8List) apiObj,
       wire_cst_record_ffi_url_list_prim_u_8_strict wireObj) {
@@ -1965,22 +1999,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       (BigInt, OutPoint) apiObj, wire_cst_record_u_64_out_point wireObj) {
     wireObj.field0 = cst_encode_u_64(apiObj.$1);
     cst_api_fill_to_wire_out_point(apiObj.$2, wireObj.field1);
-  }
-
-  @protected
-  void cst_api_fill_to_wire_request_context_v_1(
-      RequestContextV1 apiObj, wire_cst_request_context_v_1 wireObj) {
-    cst_api_fill_to_wire_record_ffi_url_list_prim_u_8_strict(
-        apiObj.request, wireObj.request);
-    cst_api_fill_to_wire_ffi_context_v_1(apiObj.contextV1, wireObj.context_v1);
-  }
-
-  @protected
-  void cst_api_fill_to_wire_request_context_v_2(
-      RequestContextV2 apiObj, wire_cst_request_context_v_2 wireObj) {
-    cst_api_fill_to_wire_record_ffi_url_list_prim_u_8_strict(
-        apiObj.request, wireObj.request);
-    cst_api_fill_to_wire_ffi_context_v_2(apiObj.contextV2, wireObj.context_v2);
   }
 
   @protected
@@ -2015,6 +2033,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   int cst_encode_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal(
       ArcV2PayjoinProposal raw);
+
+  @protected
+  int cst_encode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(ArcContextV1 raw);
 
   @protected
   int cst_encode_RustOpaque_Arcpayjoin_ffisendv2ContextV2(ArcContextV2 raw);
@@ -2078,9 +2099,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   int cst_encode_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal(
       V2UncheckedProposal raw);
-
-  @protected
-  int cst_encode_RustOpaque_payjoin_ffisendv1ContextV1(ContextV1 raw);
 
   @protected
   int cst_encode_RustOpaque_payjoin_ffisendv1RequestBuilder(RequestBuilder raw);
@@ -2165,6 +2183,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       ArcV2PayjoinProposal self, SseSerializer serializer);
 
   @protected
+  void sse_encode_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      ArcContextV1 self, SseSerializer serializer);
+
+  @protected
   void sse_encode_RustOpaque_Arcpayjoin_ffisendv2ContextV2(
       ArcContextV2 self, SseSerializer serializer);
 
@@ -2227,10 +2249,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal(
       V2UncheckedProposal self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_RustOpaque_payjoin_ffisendv1ContextV1(
-      ContextV1 self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_payjoin_ffisendv1RequestBuilder(
@@ -2443,6 +2461,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       FfiProvisionalProposal self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_request(FfiRequest self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_request_builder(
       FfiRequestBuilder self, SseSerializer serializer);
 
@@ -2550,6 +2571,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_payjoin_error(PayjoinError self, SseSerializer serializer);
 
   @protected
+  void sse_encode_record_ffi_request_ffi_context_v_1(
+      (FfiRequest, FfiContextV1) self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_record_ffi_request_ffi_context_v_2(
+      (FfiRequest, FfiContextV2) self, SseSerializer serializer);
+
+  @protected
   void sse_encode_record_ffi_url_list_prim_u_8_strict(
       (FfiUrl, Uint8List) self, SseSerializer serializer);
 
@@ -2566,14 +2595,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_record_u_64_out_point(
       (BigInt, OutPoint) self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_request_context_v_1(
-      RequestContextV1 self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_request_context_v_2(
-      RequestContextV2 self, SseSerializer serializer);
 
   @protected
   void sse_encode_tx_out(TxOut self, SseSerializer serializer);
@@ -4017,11 +4038,11 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__send__ffi_request_context_extract_v1(
     int port_,
-    ffi.Pointer<wire_cst_ffi_request_context> ptr,
+    ffi.Pointer<wire_cst_ffi_request_context> that,
   ) {
     return _wire__crate__api__send__ffi_request_context_extract_v1(
       port_,
-      ptr,
+      that,
     );
   }
 
@@ -4036,12 +4057,12 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__send__ffi_request_context_extract_v2(
     int port_,
-    ffi.Pointer<wire_cst_ffi_request_context> ptr,
+    ffi.Pointer<wire_cst_ffi_request_context> that,
     ffi.Pointer<wire_cst_ffi_url> ohttp_proxy_url,
   ) {
     return _wire__crate__api__send__ffi_request_context_extract_v2(
       port_,
-      ptr,
+      that,
       ohttp_proxy_url,
     );
   }
@@ -4425,6 +4446,36 @@ class coreWire implements BaseWire {
           'frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal');
   late final _rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposal =
       _rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffireceivev2V2PayjoinProposalPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1');
+  late final _rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1 =
+      _rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1Ptr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1');
+  late final _rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1 =
+      _rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1Ptr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv2ContextV2(
@@ -4935,36 +4986,6 @@ class coreWire implements BaseWire {
           'frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal');
   late final _rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposal =
       _rust_arc_decrement_strong_count_RustOpaque_payjoin_ffireceivev2V2UncheckedProposalPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
-
-  void rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(
-    ffi.Pointer<ffi.Void> ptr,
-  ) {
-    return _rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(
-      ptr,
-    );
-  }
-
-  late final _rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1');
-  late final _rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1 =
-      _rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
-
-  void rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(
-    ffi.Pointer<ffi.Void> ptr,
-  ) {
-    return _rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(
-      ptr,
-    );
-  }
-
-  late final _rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1');
-  late final _rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1 =
-      _rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1Ptr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
@@ -5925,6 +5946,12 @@ final class wire_cst_list_prim_u_64_strict extends ffi.Struct {
   external int len;
 }
 
+final class wire_cst_ffi_request extends ffi.Struct {
+  external wire_cst_ffi_url ffi_url;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> body;
+}
+
 final class wire_cst_PayjoinError_InvalidAddress extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
 }
@@ -6042,6 +6069,18 @@ final class wire_cst_payjoin_error extends ffi.Struct {
   external PayjoinErrorKind kind;
 }
 
+final class wire_cst_record_ffi_request_ffi_context_v_1 extends ffi.Struct {
+  external wire_cst_ffi_request field0;
+
+  external wire_cst_ffi_context_v_1 field1;
+}
+
+final class wire_cst_record_ffi_request_ffi_context_v_2 extends ffi.Struct {
+  external wire_cst_ffi_request field0;
+
+  external wire_cst_ffi_context_v_2 field1;
+}
+
 final class wire_cst_record_ffi_url_list_prim_u_8_strict extends ffi.Struct {
   external wire_cst_ffi_url field0;
 
@@ -6053,16 +6092,4 @@ final class wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_respo
   external wire_cst_record_ffi_url_list_prim_u_8_strict field0;
 
   external wire_cst_ffi_client_response field1;
-}
-
-final class wire_cst_request_context_v_1 extends ffi.Struct {
-  external wire_cst_record_ffi_url_list_prim_u_8_strict request;
-
-  external wire_cst_ffi_context_v_1 context_v1;
-}
-
-final class wire_cst_request_context_v_2 extends ffi.Struct {
-  external wire_cst_record_ffi_url_list_prim_u_8_strict request;
-
-  external wire_cst_ffi_context_v_2 context_v2;
 }

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -2787,12 +2787,12 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned(
     int port_,
-    ffi.Pointer<wire_cst_ffi_maybe_inputs_owned> ptr,
+    ffi.Pointer<wire_cst_ffi_maybe_inputs_owned> that,
     ffi.Pointer<ffi.Void> is_owned,
   ) {
     return _wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned(
       port_,
-      ptr,
+      that,
       is_owned,
     );
   }
@@ -2814,12 +2814,12 @@ class coreWire implements BaseWire {
   void
       wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before(
     int port_,
-    ffi.Pointer<wire_cst_ffi_maybe_inputs_seen> ptr,
+    ffi.Pointer<wire_cst_ffi_maybe_inputs_seen> that,
     ffi.Pointer<ffi.Void> is_known,
   ) {
     return _wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before(
       port_,
-      ptr,
+      that,
       is_known,
     );
   }
@@ -2841,11 +2841,11 @@ class coreWire implements BaseWire {
   void
       wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts(
     int port_,
-    ffi.Pointer<wire_cst_ffi_maybe_mixed_input_scripts> ptr,
+    ffi.Pointer<wire_cst_ffi_maybe_mixed_input_scripts> that,
   ) {
     return _wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts(
       port_,
-      ptr,
+      that,
     );
   }
 
@@ -2863,12 +2863,12 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs(
     int port_,
-    ffi.Pointer<wire_cst_ffi_outputs_unknown> ptr,
+    ffi.Pointer<wire_cst_ffi_outputs_unknown> that,
     ffi.Pointer<ffi.Void> is_receiver_output,
   ) {
     return _wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs(
       port_,
-      ptr,
+      that,
       is_receiver_output,
     );
   }
@@ -3038,15 +3038,15 @@ class coreWire implements BaseWire {
 
   void wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal(
     int port_,
-    ffi.Pointer<wire_cst_ffi_provisional_proposal> ptr,
+    ffi.Pointer<wire_cst_ffi_provisional_proposal> that,
     ffi.Pointer<ffi.Void> process_psbt,
-    ffi.Pointer<ffi.Uint64> min_feerate_sat_per_vb,
+    ffi.Pointer<ffi.Uint64> min_fee_rate_sat_per_vb,
   ) {
     return _wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal(
       port_,
-      ptr,
+      that,
       process_psbt,
-      min_feerate_sat_per_vb,
+      min_fee_rate_sat_per_vb,
     );
   }
 
@@ -3218,11 +3218,11 @@ class coreWire implements BaseWire {
   void
       wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(
     int port_,
-    ffi.Pointer<wire_cst_ffi_unchecked_proposal> ptr,
+    ffi.Pointer<wire_cst_ffi_unchecked_proposal> that,
   ) {
     return _wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(
       port_,
-      ptr,
+      that,
     );
   }
 
@@ -3241,13 +3241,13 @@ class coreWire implements BaseWire {
   void
       wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability(
     int port_,
-    ffi.Pointer<wire_cst_ffi_unchecked_proposal> ptr,
+    ffi.Pointer<wire_cst_ffi_unchecked_proposal> that,
     ffi.Pointer<ffi.Uint64> min_fee_rate,
     ffi.Pointer<ffi.Void> can_broadcast,
   ) {
     return _wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability(
       port_,
-      ptr,
+      that,
       min_fee_rate,
       can_broadcast,
     );

--- a/lib/src/generated/lib.dart
+++ b/lib/src/generated/lib.dart
@@ -9,6 +9,9 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 // Rust type: RustOpaqueNom<Arc < payjoin_ffi :: receive :: v2 :: V2PayjoinProposal >>
 abstract class ArcV2PayjoinProposal implements RustOpaqueInterface {}
 
+// Rust type: RustOpaqueNom<Arc < payjoin_ffi :: send :: v1 :: ContextV1 >>
+abstract class ArcContextV1 implements RustOpaqueInterface {}
+
 // Rust type: RustOpaqueNom<Arc < payjoin_ffi :: send :: v2 :: ContextV2 >>
 abstract class ArcContextV2 implements RustOpaqueInterface {}
 
@@ -56,9 +59,6 @@ abstract class V2ProvisionalProposal implements RustOpaqueInterface {}
 
 // Rust type: RustOpaqueNom<payjoin_ffi :: receive :: v2 :: V2UncheckedProposal>
 abstract class V2UncheckedProposal implements RustOpaqueInterface {}
-
-// Rust type: RustOpaqueNom<payjoin_ffi :: send :: v1 :: ContextV1>
-abstract class ContextV1 implements RustOpaqueInterface {}
 
 // Rust type: RustOpaqueNom<payjoin_ffi :: send :: v1 :: RequestBuilder>
 abstract class RequestBuilder implements RustOpaqueInterface {}

--- a/lib/src/generated/utils/types.dart
+++ b/lib/src/generated/utils/types.dart
@@ -3,6 +3,7 @@
 
 // ignore_for_file: invalid_use_of_internal_member, unused_import, unnecessary_import
 
+import '../api/uri.dart';
 import '../frb_generated.dart';
 import '../lib.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
@@ -79,6 +80,27 @@ class OutPoint {
           runtimeType == other.runtimeType &&
           txid == other.txid &&
           vout == other.vout;
+}
+
+class Request {
+  final FfiUrl url;
+  final Uint8List body;
+
+  const Request({
+    required this.url,
+    required this.body,
+  });
+
+  @override
+  int get hashCode => url.hashCode ^ body.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Request &&
+          runtimeType == other.runtimeType &&
+          url == other.url &&
+          body == other.body;
 }
 
 class TxOut {

--- a/lib/src/generated/utils/types.dart
+++ b/lib/src/generated/utils/types.dart
@@ -4,7 +4,26 @@
 // ignore_for_file: invalid_use_of_internal_member, unused_import, unnecessary_import
 
 import '../frb_generated.dart';
+import '../lib.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+
+class ClientResponse {
+  final MutexOptionClientResponse field0;
+
+  const ClientResponse({
+    required this.field0,
+  });
+
+  @override
+  int get hashCode => field0.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ClientResponse &&
+          runtimeType == other.runtimeType &&
+          field0 == other.field0;
+}
 
 class Headers {
   final Map<String, String> map;

--- a/lib/uri.dart
+++ b/lib/uri.dart
@@ -27,12 +27,62 @@ class PjUriBuilder extends FfiPjUriBuilder {
       throw mapPayjoinError(e);
     }
   }
+
+  @override
+  PjUriBuilder amount({required BigInt amount}) {
+    try {
+      final res = super.amount(amount: amount);
+      return PjUriBuilder(internal: res.internal);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
+
+  @override
+  PjUriBuilder label({required String label}) {
+    try {
+      final res = super.label(label: label);
+      return PjUriBuilder(internal: res.internal);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
+
+  @override
+  PjUriBuilder message({required String message}) {
+    try {
+      final res = super.message(message: message);
+      return PjUriBuilder(internal: res.internal);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
+
+  @override
+  PjUriBuilder pjos({required bool pjos}) {
+    try {
+      final res = super.pjos(pjos: pjos);
+      return PjUriBuilder(internal: res.internal);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
+
+  @override
+  PjUri build() {
+    try {
+      final res = super.build();
+      return PjUri._(field0: res.field0);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
 }
 
 class Uri extends FfiUri {
   Uri._({required super.field0});
 
-  static Future<Uri> fromString(String uri) async {
+  static Future<Uri> fromStr(String uri) async {
     try {
       await PConfig.initializeApp();
       final res = await FfiUri.fromStr(uri: uri);
@@ -69,11 +119,6 @@ class Uri extends FfiUri {
       throw mapPayjoinError(e);
     }
   }
-
-  @override
-  String toString() {
-    return super.asString();
-  }
 }
 
 class PjUri extends FfiPjUri {
@@ -97,16 +142,11 @@ class PjUri extends FfiPjUri {
       throw mapPayjoinError(e);
     }
   }
-
-  @override
-  String toString() {
-    return super.asString();
-  }
 }
 
 class Url extends FfiUrl {
   Url._({required super.field0});
-  static Future<Url> fromString(String uri) async {
+  static Future<Url> fromStr(String uri) async {
     try {
       await PConfig.initializeApp();
       final res = await FfiUrl.fromStr(url: uri);
@@ -123,11 +163,6 @@ class Url extends FfiUrl {
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
     }
-  }
-
-  @override
-  String toString() {
-    return super.asString();
   }
 }
 

--- a/lib/uri.dart
+++ b/lib/uri.dart
@@ -146,8 +146,9 @@ class PjUri extends FfiPjUri {
 
 class Url extends FfiUrl {
   Url._({required super.field0});
-  static Url fromStr(String uri) {
+  static Future<Url> fromStr(String uri) async {
     try {
+      await PConfig.initializeApp();
       final res = FfiUrl.fromStr(url: uri);
       return Url._(field0: res.field0);
     } on error.PayjoinError catch (e) {

--- a/lib/uri.dart
+++ b/lib/uri.dart
@@ -85,7 +85,7 @@ class Uri extends FfiUri {
   static Future<Uri> fromStr(String uri) async {
     try {
       await PConfig.initializeApp();
-      final res = await FfiUri.fromStr(uri: uri);
+      final res = FfiUri.fromStr(uri: uri);
       return Uri._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);
@@ -146,10 +146,9 @@ class PjUri extends FfiPjUri {
 
 class Url extends FfiUrl {
   Url._({required super.field0});
-  static Future<Url> fromStr(String uri) async {
+  static Url fromStr(String uri) {
     try {
-      await PConfig.initializeApp();
-      final res = await FfiUrl.fromStr(url: uri);
+      final res = FfiUrl.fromStr(url: uri);
       return Url._(field0: res.field0);
     } on error.PayjoinError catch (e) {
       throw mapPayjoinError(e);

--- a/rust/src/api/receive.rs
+++ b/rust/src/api/receive.rs
@@ -300,7 +300,6 @@ impl FfiActiveSession {
         self.0.public_key()
     }
 
-    #[frb(sync)]
     pub fn pj_url(&self) -> FfiUrl {
         self.0.pj_url().into()
     }

--- a/rust/src/api/receive.rs
+++ b/rust/src/api/receive.rs
@@ -1,7 +1,7 @@
 use crate::api::uri::{FfiOhttpKeys, FfiPjUriBuilder, FfiUrl};
 use crate::frb_generated::RustOpaque;
 pub use crate::utils::error::PayjoinError;
-use crate::utils::types::{ClientResponse, Headers, OutPoint, TxOut};
+use crate::utils::types::{ClientResponse, Headers, OutPoint, Request, TxOut};
 use flutter_rust_bridge::{frb, DartFnFuture};
 use std::collections::HashMap;
 pub use std::sync::Arc;
@@ -233,7 +233,7 @@ impl FfiPayjoinProposal {
         self.0.is_output_substitution_disabled()
     }
     pub fn owned_vouts(&self) -> Vec<u64> {
-        self.0.owned_vouts().iter().map(|x| (*x).into()).collect()
+        self.0.owned_vouts().to_vec()
     }
     pub fn psbt(&self) -> String {
         self.0.psbt()
@@ -268,10 +268,10 @@ impl FfiSessionInitializer {
         .into())
     }
 
-    pub fn extract_req(&self) -> Result<((FfiUrl, Vec<u8>), ClientResponse), PayjoinError> {
+    pub fn extract_req(&self) -> Result<(Request, ClientResponse), PayjoinError> {
         self.0
             .extract_req()
-            .map(|e| (((*e.0.url).clone().into(), e.0.body), e.1.into()))
+            .map(|e| (e.0.into(), e.1.into()))
             .map_err(|e| e.into())
     }
     pub fn process_res(
@@ -308,10 +308,10 @@ impl FfiActiveSession {
     pub fn pj_uri_builder(&self) -> FfiPjUriBuilder {
         self.0.pj_uri_builder().into()
     }
-    pub fn extract_req(&self) -> Result<((FfiUrl, Vec<u8>), ClientResponse), PayjoinError> {
+    pub fn extract_req(&self) -> Result<(Request, ClientResponse), PayjoinError> {
         self.0
             .extract_req()
-            .map(|e| (((*e.0.url).clone().into(), e.0.body), e.1.into()))
+            .map(|e| (e.0.into(), e.1.into()))
             .map_err(|e| e.into())
     }
     pub fn process_res(
@@ -549,7 +549,7 @@ impl FfiV2PayjoinProposal {
         self.0.is_output_substitution_disabled()
     }
     pub fn owned_vouts(&self) -> Vec<u64> {
-        self.0.owned_vouts().iter().map(|x| (*x).into()).collect()
+        self.0.owned_vouts().to_vec()
     }
     pub fn psbt(&self) -> String {
         self.0.psbt()
@@ -557,11 +557,11 @@ impl FfiV2PayjoinProposal {
     pub fn extract_v1_req(&self) -> String {
         self.0.extract_v1_req()
     }
-    pub fn extract_v2_req(&self) -> Result<((FfiUrl, Vec<u8>), ClientResponse), PayjoinError> {
+    pub fn extract_v2_req(&self) -> Result<(Request, ClientResponse), PayjoinError> {
         self.0
             .clone()
             .extract_v2_req()
-            .map(|e| (((*e.0.url).clone().into(), e.0.body), e.1.into()))
+            .map(|e| (e.0.into(), e.1.into()))
             .map_err(|e| e.into())
     }
 

--- a/rust/src/api/send.rs
+++ b/rust/src/api/send.rs
@@ -78,66 +78,76 @@ impl From<FfiRequestContext> for payjoin_ffi::send::v1::RequestContext {
     }
 }
 impl FfiRequestContext {
-    pub fn extract_v1(ptr: Self) -> Result<RequestContextV1, PayjoinError> {
-        match ptr.0.extract_v1() {
-            Ok(e) => Ok(e.into()),
+    pub fn extract_v1(&self) -> Result<(FfiRequest, FfiContextV1), PayjoinError> {
+        match self.0.extract_v1() {
+            Ok(e) => Ok((e.request.into(), e.context_v1.into())),
             Err(e) => Err(e.into()),
         }
     }
     pub fn extract_v2(
-        ptr: Self,
+        &self,
         ohttp_proxy_url: FfiUrl,
-    ) -> Result<RequestContextV2, PayjoinError> {
-        match ptr.0.extract_v2(Arc::new((*ohttp_proxy_url.0).clone())) {
-            Ok(e) => Ok(e.into()),
+    ) -> Result<(FfiRequest, FfiContextV2), PayjoinError> {
+        match self.0.extract_v2(Arc::new((*ohttp_proxy_url.0).clone())) {
+            Ok(e) => Ok((e.request.into(), e.context_v2.into())),
             Err(e) => Err(e.into()),
         }
     }
 }
 
 #[derive(Clone)]
-pub struct RequestContextV1 {
-    pub request: (FfiUrl, Vec<u8>),
+pub struct FfiRequest {
+    pub ffi_url: FfiUrl,
+    pub body: Vec<u8>,
+}
+
+impl From<payjoin_ffi::types::Request> for FfiRequest {
+    fn from(value: payjoin_ffi::types::Request) -> Self {
+        Self {
+            ffi_url: (*value.url).clone().into(),
+            body: value.body,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FfiRequestContextV1 {
+    pub request: FfiRequest,
     pub context_v1: FfiContextV1,
 }
 
-impl From<Arc<payjoin_ffi::send::v1::RequestContextV1>> for RequestContextV1 {
-    fn from(value: Arc<payjoin_ffi::send::v1::RequestContextV1>) -> Self {
+impl From<payjoin_ffi::send::v1::RequestContextV1> for FfiRequestContextV1 {
+    fn from(value: payjoin_ffi::send::v1::RequestContextV1) -> Self {
         Self {
-            request: (
-                (*value.request.url).clone().into(),
-                value.request.body.clone(),
-            ),
-            context_v1: (*value.context_v1).clone().into(),
+            request: FfiRequest {
+                ffi_url: (*value.request.url).clone().into(),
+                body: value.request.body.clone(),
+            },
+            context_v1: value.context_v1.into(),
         }
     }
 }
 
-impl From<payjoin_ffi::send::v1::RequestContextV1> for RequestContextV1 {
-    fn from(value: payjoin_ffi::send::v1::RequestContextV1) -> Self {
-        Self {
-            request: ((*value.request.url).clone().into(), value.request.body),
-            context_v1: (*value.context_v1).clone().into(),
-        }
-    }
-}
-pub struct RequestContextV2 {
-    pub request: (FfiUrl, Vec<u8>),
+pub struct FfiRequestContextV2 {
+    pub request: FfiRequest,
     pub context_v2: FfiContextV2,
 }
 
-impl From<payjoin_ffi::send::v1::RequestContextV2> for RequestContextV2 {
+impl From<payjoin_ffi::send::v1::RequestContextV2> for FfiRequestContextV2 {
     fn from(value: payjoin_ffi::send::v1::RequestContextV2) -> Self {
         Self {
-            request: ((*value.request.url).clone().into(), value.request.body),
+            request: FfiRequest {
+                ffi_url: (*value.request.url).clone().into(),
+                body: value.request.body,
+            },
             context_v2: value.context_v2.into(),
         }
     }
 }
 #[derive(Clone)]
-pub struct FfiContextV1(pub RustOpaque<payjoin_ffi::send::v1::ContextV1>);
-impl From<payjoin_ffi::send::v1::ContextV1> for FfiContextV1 {
-    fn from(value: payjoin_ffi::send::v1::ContextV1) -> Self {
+pub struct FfiContextV1(pub RustOpaque<Arc<payjoin_ffi::send::v1::ContextV1>>);
+impl From<Arc<payjoin_ffi::send::v1::ContextV1>> for FfiContextV1 {
+    fn from(value: Arc<payjoin_ffi::send::v1::ContextV1>) -> Self {
         Self(RustOpaque::new(value))
     }
 }

--- a/rust/src/api/send.rs
+++ b/rust/src/api/send.rs
@@ -1,5 +1,6 @@
 use crate::api::uri::{FfiPjUri, FfiUrl};
 use crate::frb_generated::RustOpaque;
+use crate::utils::types::Request;
 use std::sync::Arc;
 
 use super::receive::PayjoinError;
@@ -78,7 +79,7 @@ impl From<FfiRequestContext> for payjoin_ffi::send::v1::RequestContext {
     }
 }
 impl FfiRequestContext {
-    pub fn extract_v1(&self) -> Result<(FfiRequest, FfiContextV1), PayjoinError> {
+    pub fn extract_v1(&self) -> Result<(Request, FfiContextV1), PayjoinError> {
         match self.0.extract_v1() {
             Ok(e) => Ok((e.request.into(), e.context_v1.into())),
             Err(e) => Err(e.into()),
@@ -87,7 +88,7 @@ impl FfiRequestContext {
     pub fn extract_v2(
         &self,
         ohttp_proxy_url: FfiUrl,
-    ) -> Result<(FfiRequest, FfiContextV2), PayjoinError> {
+    ) -> Result<(Request, FfiContextV2), PayjoinError> {
         match self.0.extract_v2(Arc::new((*ohttp_proxy_url.0).clone())) {
             Ok(e) => Ok((e.request.into(), e.context_v2.into())),
             Err(e) => Err(e.into()),
@@ -96,31 +97,16 @@ impl FfiRequestContext {
 }
 
 #[derive(Clone)]
-pub struct FfiRequest {
-    pub ffi_url: FfiUrl,
-    pub body: Vec<u8>,
-}
-
-impl From<payjoin_ffi::types::Request> for FfiRequest {
-    fn from(value: payjoin_ffi::types::Request) -> Self {
-        Self {
-            ffi_url: (*value.url).clone().into(),
-            body: value.body,
-        }
-    }
-}
-
-#[derive(Clone)]
 pub struct FfiRequestContextV1 {
-    pub request: FfiRequest,
+    pub request: Request,
     pub context_v1: FfiContextV1,
 }
 
 impl From<payjoin_ffi::send::v1::RequestContextV1> for FfiRequestContextV1 {
     fn from(value: payjoin_ffi::send::v1::RequestContextV1) -> Self {
         Self {
-            request: FfiRequest {
-                ffi_url: (*value.request.url).clone().into(),
+            request: Request {
+                url: (*value.request.url).clone().into(),
                 body: value.request.body.clone(),
             },
             context_v1: value.context_v1.into(),
@@ -129,15 +115,15 @@ impl From<payjoin_ffi::send::v1::RequestContextV1> for FfiRequestContextV1 {
 }
 
 pub struct FfiRequestContextV2 {
-    pub request: FfiRequest,
+    pub request: Request,
     pub context_v2: FfiContextV2,
 }
 
 impl From<payjoin_ffi::send::v1::RequestContextV2> for FfiRequestContextV2 {
     fn from(value: payjoin_ffi::send::v1::RequestContextV2) -> Self {
         Self {
-            request: FfiRequest {
-                ffi_url: (*value.request.url).clone().into(),
+            request: Request {
+                url: (*value.request.url).clone().into(),
                 body: value.request.body,
             },
             context_v2: value.context_v2.into(),

--- a/rust/src/api/uri.rs
+++ b/rust/src/api/uri.rs
@@ -11,7 +11,8 @@ impl From<payjoin_ffi::uri::Url> for FfiUrl {
 }
 
 impl FfiUrl {
-    pub fn from_str(url: String) -> anyhow::Result<FfiUrl, PayjoinError> {
+    #[frb(sync)]
+    pub fn from_str(url: String) -> Result<Self, PayjoinError> {
         match payjoin_ffi::uri::Url::from_str(url) {
             Ok(e) => Ok(e.into()),
             Err(e) => Err(e.into()),
@@ -75,7 +76,7 @@ impl FfiPjUriBuilder {
         payjoin_ffi::uri::PjUriBuilder::new(
             address,
             (*pj.0).clone(),
-            ohttp_keys.map(|e| (*e.0).clone().into()),
+            ohttp_keys.map(|e| (*e.0).clone()),
             expiry,
         )
         .map_err(|e| e.into())
@@ -116,6 +117,7 @@ impl From<payjoin_ffi::uri::Uri> for FfiUri {
     }
 }
 impl FfiUri {
+    #[frb(sync)]
     pub fn from_str(uri: String) -> anyhow::Result<FfiUri, PayjoinError> {
         match payjoin_ffi::uri::Uri::from_str(uri) {
             Ok(e) => Ok(e.into()),

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -214,6 +214,13 @@ impl CstDecode<String> for *mut wire_cst_list_prim_u_8_strict {
         String::from_utf8(vec).unwrap()
     }
 }
+impl CstDecode<crate::utils::types::ClientResponse> for *mut wire_cst_client_response {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::utils::types::ClientResponse {
+        let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+        CstDecode::<crate::utils::types::ClientResponse>::cst_decode(*wrap).into()
+    }
+}
 impl CstDecode<f64> for *mut f64 {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> f64 {
@@ -225,13 +232,6 @@ impl CstDecode<crate::api::receive::FfiActiveSession> for *mut wire_cst_ffi_acti
     fn cst_decode(self) -> crate::api::receive::FfiActiveSession {
         let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
         CstDecode::<crate::api::receive::FfiActiveSession>::cst_decode(*wrap).into()
-    }
-}
-impl CstDecode<crate::api::receive::FfiClientResponse> for *mut wire_cst_ffi_client_response {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> crate::api::receive::FfiClientResponse {
-        let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
-        CstDecode::<crate::api::receive::FfiClientResponse>::cst_decode(*wrap).into()
     }
 }
 impl CstDecode<crate::api::send::FfiContextV1> for *mut wire_cst_ffi_context_v_1 {
@@ -453,16 +453,16 @@ impl CstDecode<u8> for *mut u8 {
         unsafe { *flutter_rust_bridge::for_generated::box_from_leak_ptr(self) }
     }
 }
+impl CstDecode<crate::utils::types::ClientResponse> for wire_cst_client_response {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::utils::types::ClientResponse {
+        crate::utils::types::ClientResponse(self.field0.cst_decode())
+    }
+}
 impl CstDecode<crate::api::receive::FfiActiveSession> for wire_cst_ffi_active_session {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::receive::FfiActiveSession {
         crate::api::receive::FfiActiveSession(self.field0.cst_decode())
-    }
-}
-impl CstDecode<crate::api::receive::FfiClientResponse> for wire_cst_ffi_client_response {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> crate::api::receive::FfiClientResponse {
-        crate::api::receive::FfiClientResponse(self.field0.cst_decode())
     }
 }
 impl CstDecode<crate::api::send::FfiContextV1> for wire_cst_ffi_context_v_1 {
@@ -847,15 +847,15 @@ impl CstDecode<(crate::api::uri::FfiUrl, Vec<u8>)>
 impl
     CstDecode<(
         (crate::api::uri::FfiUrl, Vec<u8>),
-        crate::api::receive::FfiClientResponse,
-    )> for wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response
+        crate::utils::types::ClientResponse,
+    )> for wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response
 {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(
         self,
     ) -> (
         (crate::api::uri::FfiUrl, Vec<u8>),
-        crate::api::receive::FfiClientResponse,
+        crate::utils::types::ClientResponse,
     ) {
         (self.field0.cst_decode(), self.field1.cst_decode())
     }
@@ -881,6 +881,18 @@ impl CstDecode<crate::utils::types::TxOut> for wire_cst_tx_out {
         }
     }
 }
+impl NewWithNullPtr for wire_cst_client_response {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            field0: Default::default(),
+        }
+    }
+}
+impl Default for wire_cst_client_response {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
 impl NewWithNullPtr for wire_cst_ffi_active_session {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -889,18 +901,6 @@ impl NewWithNullPtr for wire_cst_ffi_active_session {
     }
 }
 impl Default for wire_cst_ffi_active_session {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-impl NewWithNullPtr for wire_cst_ffi_client_response {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
-    }
-}
-impl Default for wire_cst_ffi_client_response {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1283,7 +1283,7 @@ impl Default for wire_cst_record_ffi_url_list_prim_u_8_strict {
         Self::new_with_null_ptr()
     }
 }
-impl NewWithNullPtr for wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response {
+impl NewWithNullPtr for wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: Default::default(),
@@ -1291,7 +1291,7 @@ impl NewWithNullPtr for wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_
         }
     }
 }
-impl Default for wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response {
+impl Default for wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1348,23 +1348,23 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__io__fetch_ohttp_keys(
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_extract_req(
     port_: i64,
-    ptr: *mut wire_cst_ffi_active_session,
+    that: *mut wire_cst_ffi_active_session,
 ) {
-    wire__crate__api__receive__ffi_active_session_extract_req_impl(port_, ptr)
+    wire__crate__api__receive__ffi_active_session_extract_req_impl(port_, that)
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_uri_builder(
-    ptr: *mut wire_cst_ffi_active_session,
+    that: *mut wire_cst_ffi_active_session,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
-    wire__crate__api__receive__ffi_active_session_pj_uri_builder_impl(ptr)
+    wire__crate__api__receive__ffi_active_session_pj_uri_builder_impl(that)
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url(
-    ptr: *mut wire_cst_ffi_active_session,
+    that: *mut wire_cst_ffi_active_session,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
-    wire__crate__api__receive__ffi_active_session_pj_url_impl(ptr)
+    wire__crate__api__receive__ffi_active_session_pj_url_impl(that)
 }
 
 #[no_mangle]
@@ -1372,7 +1372,7 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_s
     port_: i64,
     that: *mut wire_cst_ffi_active_session,
     body: *mut wire_cst_list_prim_u_8_loose,
-    ctx: *mut wire_cst_ffi_client_response,
+    ctx: *mut wire_cst_client_response,
 ) {
     wire__crate__api__receive__ffi_active_session_process_res_impl(port_, that, body, ctx)
 }
@@ -1531,9 +1531,9 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisio
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_initializer_extract_req(
     port_: i64,
-    ptr: *mut wire_cst_ffi_session_initializer,
+    that: *mut wire_cst_ffi_session_initializer,
 ) {
-    wire__crate__api__receive__ffi_session_initializer_extract_req_impl(port_, ptr)
+    wire__crate__api__receive__ffi_session_initializer_extract_req_impl(port_, that)
 }
 
 #[no_mangle]
@@ -1562,7 +1562,7 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_
     port_: i64,
     that: *mut wire_cst_ffi_session_initializer,
     body: *mut wire_cst_list_prim_u_8_loose,
-    ctx: *mut wire_cst_ffi_client_response,
+    ctx: *mut wire_cst_client_response,
 ) {
     wire__crate__api__receive__ffi_session_initializer_process_res_impl(port_, that, body, ctx)
 }
@@ -1666,9 +1666,9 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payj
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req(
     port_: i64,
-    ptr: *mut wire_cst_ffi_v_2_payjoin_proposal,
+    that: *mut wire_cst_ffi_v_2_payjoin_proposal,
 ) {
-    wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req_impl(port_, ptr)
+    wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req_impl(port_, that)
 }
 
 #[no_mangle]
@@ -1694,7 +1694,7 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payj
     port_: i64,
     that: *mut wire_cst_ffi_v_2_payjoin_proposal,
     res: *mut wire_cst_list_prim_u_8_loose,
-    ohttp_context: *mut wire_cst_ffi_client_response,
+    ohttp_context: *mut wire_cst_client_response,
 ) {
     wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res_impl(
         port_,
@@ -1749,13 +1749,13 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_prov
     port_: i64,
     that: *mut wire_cst_ffi_v_2_provisional_proposal,
     process_psbt: *const std::ffi::c_void,
-    min_feerate_sat_per_vb: *mut u64,
+    min_fee_rate_sat_per_vb: *mut u64,
 ) {
     wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal_impl(
         port_,
         that,
         process_psbt,
-        min_feerate_sat_per_vb,
+        min_fee_rate_sat_per_vb,
     )
 }
 
@@ -2035,10 +2035,9 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_check_pj
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_from_str(
-    port_: i64,
     uri: *mut wire_cst_list_prim_u_8_strict,
-) {
-    wire__crate__api__uri__ffi_uri_from_str_impl(port_, uri)
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__uri__ffi_uri_from_str_impl(uri)
 }
 
 #[no_mangle]
@@ -2050,10 +2049,9 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_as_strin
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_from_str(
-    port_: i64,
     url: *mut wire_cst_list_prim_u_8_strict,
-) {
-    wire__crate__api__uri__ffi_url_from_str_impl(port_, url)
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__uri__ffi_url_from_str_impl(url)
 }
 
 #[no_mangle]
@@ -2544,6 +2542,14 @@ pub extern "C" fn frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpa
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_cst_new_box_autoadd_client_response(
+) -> *mut wire_cst_client_response {
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(
+        wire_cst_client_response::new_with_null_ptr(),
+    )
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_cst_new_box_autoadd_f_64(value: f64) -> *mut f64 {
     flutter_rust_bridge::for_generated::new_leak_box_ptr(value)
 }
@@ -2553,14 +2559,6 @@ pub extern "C" fn frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_active_session(
 ) -> *mut wire_cst_ffi_active_session {
     flutter_rust_bridge::for_generated::new_leak_box_ptr(
         wire_cst_ffi_active_session::new_with_null_ptr(),
-    )
-}
-
-#[no_mangle]
-pub extern "C" fn frbgen_payjoin_flutter_cst_new_box_autoadd_ffi_client_response(
-) -> *mut wire_cst_ffi_client_response {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(
-        wire_cst_ffi_client_response::new_with_null_ptr(),
     )
 }
 
@@ -2851,12 +2849,12 @@ pub extern "C" fn frbgen_payjoin_flutter_cst_new_list_record_u_64_out_point(
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_ffi_active_session {
+pub struct wire_cst_client_response {
     field0: usize,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_ffi_client_response {
+pub struct wire_cst_ffi_active_session {
     field0: usize,
 }
 #[repr(C)]
@@ -3171,9 +3169,9 @@ pub struct wire_cst_record_ffi_url_list_prim_u_8_strict {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_ffi_client_response {
+pub struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
     field0: wire_cst_record_ffi_url_list_prim_u_8_strict,
-    field1: wire_cst_ffi_client_response,
+    field1: wire_cst_client_response,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -535,15 +535,6 @@ impl CstDecode<crate::api::receive::FfiProvisionalProposal> for wire_cst_ffi_pro
         crate::api::receive::FfiProvisionalProposal(self.field0.cst_decode())
     }
 }
-impl CstDecode<crate::api::send::FfiRequest> for wire_cst_ffi_request {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> crate::api::send::FfiRequest {
-        crate::api::send::FfiRequest {
-            ffi_url: self.ffi_url.cst_decode(),
-            body: self.body.cst_decode(),
-        }
-    }
-}
 impl CstDecode<crate::api::send::FfiRequestBuilder> for wire_cst_ffi_request_builder {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::send::FfiRequestBuilder {
@@ -820,43 +811,35 @@ impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
         }
     }
 }
-impl CstDecode<(crate::api::send::FfiRequest, crate::api::send::FfiContextV1)>
-    for wire_cst_record_ffi_request_ffi_context_v_1
-{
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> (crate::api::send::FfiRequest, crate::api::send::FfiContextV1) {
-        (self.field0.cst_decode(), self.field1.cst_decode())
-    }
-}
-impl CstDecode<(crate::api::send::FfiRequest, crate::api::send::FfiContextV2)>
-    for wire_cst_record_ffi_request_ffi_context_v_2
-{
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> (crate::api::send::FfiRequest, crate::api::send::FfiContextV2) {
-        (self.field0.cst_decode(), self.field1.cst_decode())
-    }
-}
-impl CstDecode<(crate::api::uri::FfiUrl, Vec<u8>)>
-    for wire_cst_record_ffi_url_list_prim_u_8_strict
-{
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> (crate::api::uri::FfiUrl, Vec<u8>) {
-        (self.field0.cst_decode(), self.field1.cst_decode())
-    }
-}
 impl
     CstDecode<(
-        (crate::api::uri::FfiUrl, Vec<u8>),
+        crate::utils::types::Request,
         crate::utils::types::ClientResponse,
-    )> for wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response
+    )> for wire_cst_record_request_client_response
 {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(
         self,
     ) -> (
-        (crate::api::uri::FfiUrl, Vec<u8>),
+        crate::utils::types::Request,
         crate::utils::types::ClientResponse,
     ) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
+impl CstDecode<(crate::utils::types::Request, crate::api::send::FfiContextV1)>
+    for wire_cst_record_request_ffi_context_v_1
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (crate::utils::types::Request, crate::api::send::FfiContextV1) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
+impl CstDecode<(crate::utils::types::Request, crate::api::send::FfiContextV2)>
+    for wire_cst_record_request_ffi_context_v_2
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (crate::utils::types::Request, crate::api::send::FfiContextV2) {
         (self.field0.cst_decode(), self.field1.cst_decode())
     }
 }
@@ -870,6 +853,15 @@ impl CstDecode<(u64, crate::utils::types::OutPoint)> for wire_cst_record_u_64_ou
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> (u64, crate::utils::types::OutPoint) {
         (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
+impl CstDecode<crate::utils::types::Request> for wire_cst_request {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::utils::types::Request {
+        crate::utils::types::Request {
+            url: self.url.cst_decode(),
+            body: self.body.cst_decode(),
+        }
     }
 }
 impl CstDecode<crate::utils::types::TxOut> for wire_cst_tx_out {
@@ -1033,19 +1025,6 @@ impl NewWithNullPtr for wire_cst_ffi_provisional_proposal {
     }
 }
 impl Default for wire_cst_ffi_provisional_proposal {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-impl NewWithNullPtr for wire_cst_ffi_request {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            ffi_url: Default::default(),
-            body: core::ptr::null_mut(),
-        }
-    }
-}
-impl Default for wire_cst_ffi_request {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1244,7 +1223,7 @@ impl Default for wire_cst_payjoin_error {
         Self::new_with_null_ptr()
     }
 }
-impl NewWithNullPtr for wire_cst_record_ffi_request_ffi_context_v_1 {
+impl NewWithNullPtr for wire_cst_record_request_client_response {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: Default::default(),
@@ -1252,12 +1231,12 @@ impl NewWithNullPtr for wire_cst_record_ffi_request_ffi_context_v_1 {
         }
     }
 }
-impl Default for wire_cst_record_ffi_request_ffi_context_v_1 {
+impl Default for wire_cst_record_request_client_response {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
 }
-impl NewWithNullPtr for wire_cst_record_ffi_request_ffi_context_v_2 {
+impl NewWithNullPtr for wire_cst_record_request_ffi_context_v_1 {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: Default::default(),
@@ -1265,25 +1244,12 @@ impl NewWithNullPtr for wire_cst_record_ffi_request_ffi_context_v_2 {
         }
     }
 }
-impl Default for wire_cst_record_ffi_request_ffi_context_v_2 {
+impl Default for wire_cst_record_request_ffi_context_v_1 {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
 }
-impl NewWithNullPtr for wire_cst_record_ffi_url_list_prim_u_8_strict {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-            field1: core::ptr::null_mut(),
-        }
-    }
-}
-impl Default for wire_cst_record_ffi_url_list_prim_u_8_strict {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-impl NewWithNullPtr for wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
+impl NewWithNullPtr for wire_cst_record_request_ffi_context_v_2 {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: Default::default(),
@@ -1291,7 +1257,7 @@ impl NewWithNullPtr for wire_cst_record_record_ffi_url_list_prim_u_8_strict_clie
         }
     }
 }
-impl Default for wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
+impl Default for wire_cst_record_request_ffi_context_v_2 {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1318,6 +1284,19 @@ impl NewWithNullPtr for wire_cst_record_u_64_out_point {
     }
 }
 impl Default for wire_cst_record_u_64_out_point {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_request {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            url: Default::default(),
+            body: core::ptr::null_mut(),
+        }
+    }
+}
+impl Default for wire_cst_request {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -2914,12 +2893,6 @@ pub struct wire_cst_ffi_provisional_proposal {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_ffi_request {
-    ffi_url: wire_cst_ffi_url,
-    body: *mut wire_cst_list_prim_u_8_strict,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
 pub struct wire_cst_ffi_request_builder {
     field0: usize,
 }
@@ -3151,27 +3124,21 @@ pub struct wire_cst_PayjoinError_IoError {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_record_ffi_request_ffi_context_v_1 {
-    field0: wire_cst_ffi_request,
+pub struct wire_cst_record_request_client_response {
+    field0: wire_cst_request,
+    field1: wire_cst_client_response,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_record_request_ffi_context_v_1 {
+    field0: wire_cst_request,
     field1: wire_cst_ffi_context_v_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_record_ffi_request_ffi_context_v_2 {
-    field0: wire_cst_ffi_request,
+pub struct wire_cst_record_request_ffi_context_v_2 {
+    field0: wire_cst_request,
     field1: wire_cst_ffi_context_v_2,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct wire_cst_record_ffi_url_list_prim_u_8_strict {
-    field0: wire_cst_ffi_url,
-    field1: *mut wire_cst_list_prim_u_8_strict,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct wire_cst_record_record_ffi_url_list_prim_u_8_strict_client_response {
-    field0: wire_cst_record_ffi_url_list_prim_u_8_strict,
-    field1: wire_cst_client_response,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3184,6 +3151,12 @@ pub struct wire_cst_record_string_string {
 pub struct wire_cst_record_u_64_out_point {
     field0: u64,
     field1: wire_cst_out_point,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_request {
+    url: wire_cst_ffi_url,
+    body: *mut wire_cst_list_prim_u_8_strict,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -1387,44 +1387,44 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_s
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned(
     port_: i64,
-    ptr: *mut wire_cst_ffi_maybe_inputs_owned,
+    that: *mut wire_cst_ffi_maybe_inputs_owned,
     is_owned: *const std::ffi::c_void,
 ) {
     wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned_impl(
-        port_, ptr, is_owned,
+        port_, that, is_owned,
     )
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before(
     port_: i64,
-    ptr: *mut wire_cst_ffi_maybe_inputs_seen,
+    that: *mut wire_cst_ffi_maybe_inputs_seen,
     is_known: *const std::ffi::c_void,
 ) {
     wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before_impl(
-        port_, ptr, is_known,
+        port_, that, is_known,
     )
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts(
     port_: i64,
-    ptr: *mut wire_cst_ffi_maybe_mixed_input_scripts,
+    that: *mut wire_cst_ffi_maybe_mixed_input_scripts,
 ) {
     wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts_impl(
-        port_, ptr,
+        port_, that,
     )
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs(
     port_: i64,
-    ptr: *mut wire_cst_ffi_outputs_unknown,
+    that: *mut wire_cst_ffi_outputs_unknown,
     is_receiver_output: *const std::ffi::c_void,
 ) {
     wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs_impl(
         port_,
-        ptr,
+        that,
         is_receiver_output,
     )
 }
@@ -1490,15 +1490,15 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisio
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal(
     port_: i64,
-    ptr: *mut wire_cst_ffi_provisional_proposal,
+    that: *mut wire_cst_ffi_provisional_proposal,
     process_psbt: *const std::ffi::c_void,
-    min_feerate_sat_per_vb: *mut u64,
+    min_fee_rate_sat_per_vb: *mut u64,
 ) {
     wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal_impl(
         port_,
-        ptr,
+        that,
         process_psbt,
-        min_feerate_sat_per_vb,
+        min_fee_rate_sat_per_vb,
     )
 }
 
@@ -1570,21 +1570,21 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_session_
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(
     port_: i64,
-    ptr: *mut wire_cst_ffi_unchecked_proposal,
+    that: *mut wire_cst_ffi_unchecked_proposal,
 ) {
-    wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver_impl(port_, ptr)
+    wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver_impl(port_, that)
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability(
     port_: i64,
-    ptr: *mut wire_cst_ffi_unchecked_proposal,
+    that: *mut wire_cst_ffi_unchecked_proposal,
     min_fee_rate: *mut u64,
     can_broadcast: *const std::ffi::c_void,
 ) {
     wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability_impl(
         port_,
-        ptr,
+        that,
         min_fee_rate,
         can_broadcast,
     )

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -53,6 +53,12 @@ impl CstDecode<RustOpaqueNom<Arc<payjoin_ffi::receive::v2::V2PayjoinProposal>>> 
         unsafe { decode_rust_opaque_nom(self as _) }
     }
 }
+impl CstDecode<RustOpaqueNom<Arc<payjoin_ffi::send::v1::ContextV1>>> for usize {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> RustOpaqueNom<Arc<payjoin_ffi::send::v1::ContextV1>> {
+        unsafe { decode_rust_opaque_nom(self as _) }
+    }
+}
 impl CstDecode<RustOpaqueNom<Arc<payjoin_ffi::send::v2::ContextV2>>> for usize {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> RustOpaqueNom<Arc<payjoin_ffi::send::v2::ContextV2>> {
@@ -146,12 +152,6 @@ impl CstDecode<RustOpaqueNom<payjoin_ffi::receive::v2::V2ProvisionalProposal>> f
 impl CstDecode<RustOpaqueNom<payjoin_ffi::receive::v2::V2UncheckedProposal>> for usize {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> RustOpaqueNom<payjoin_ffi::receive::v2::V2UncheckedProposal> {
-        unsafe { decode_rust_opaque_nom(self as _) }
-    }
-}
-impl CstDecode<RustOpaqueNom<payjoin_ffi::send::v1::ContextV1>> for usize {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> RustOpaqueNom<payjoin_ffi::send::v1::ContextV1> {
         unsafe { decode_rust_opaque_nom(self as _) }
     }
 }
@@ -535,6 +535,15 @@ impl CstDecode<crate::api::receive::FfiProvisionalProposal> for wire_cst_ffi_pro
         crate::api::receive::FfiProvisionalProposal(self.field0.cst_decode())
     }
 }
+impl CstDecode<crate::api::send::FfiRequest> for wire_cst_ffi_request {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::send::FfiRequest {
+        crate::api::send::FfiRequest {
+            ffi_url: self.ffi_url.cst_decode(),
+            body: self.body.cst_decode(),
+        }
+    }
+}
 impl CstDecode<crate::api::send::FfiRequestBuilder> for wire_cst_ffi_request_builder {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::send::FfiRequestBuilder {
@@ -811,6 +820,22 @@ impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
         }
     }
 }
+impl CstDecode<(crate::api::send::FfiRequest, crate::api::send::FfiContextV1)>
+    for wire_cst_record_ffi_request_ffi_context_v_1
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (crate::api::send::FfiRequest, crate::api::send::FfiContextV1) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
+impl CstDecode<(crate::api::send::FfiRequest, crate::api::send::FfiContextV2)>
+    for wire_cst_record_ffi_request_ffi_context_v_2
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (crate::api::send::FfiRequest, crate::api::send::FfiContextV2) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
 impl CstDecode<(crate::api::uri::FfiUrl, Vec<u8>)>
     for wire_cst_record_ffi_url_list_prim_u_8_strict
 {
@@ -845,24 +870,6 @@ impl CstDecode<(u64, crate::utils::types::OutPoint)> for wire_cst_record_u_64_ou
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> (u64, crate::utils::types::OutPoint) {
         (self.field0.cst_decode(), self.field1.cst_decode())
-    }
-}
-impl CstDecode<crate::api::send::RequestContextV1> for wire_cst_request_context_v_1 {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> crate::api::send::RequestContextV1 {
-        crate::api::send::RequestContextV1 {
-            request: self.request.cst_decode(),
-            context_v1: self.context_v1.cst_decode(),
-        }
-    }
-}
-impl CstDecode<crate::api::send::RequestContextV2> for wire_cst_request_context_v_2 {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> crate::api::send::RequestContextV2 {
-        crate::api::send::RequestContextV2 {
-            request: self.request.cst_decode(),
-            context_v2: self.context_v2.cst_decode(),
-        }
     }
 }
 impl CstDecode<crate::utils::types::TxOut> for wire_cst_tx_out {
@@ -1026,6 +1033,19 @@ impl NewWithNullPtr for wire_cst_ffi_provisional_proposal {
     }
 }
 impl Default for wire_cst_ffi_provisional_proposal {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_ffi_request {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            ffi_url: Default::default(),
+            body: core::ptr::null_mut(),
+        }
+    }
+}
+impl Default for wire_cst_ffi_request {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1224,6 +1244,32 @@ impl Default for wire_cst_payjoin_error {
         Self::new_with_null_ptr()
     }
 }
+impl NewWithNullPtr for wire_cst_record_ffi_request_ffi_context_v_1 {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            field0: Default::default(),
+            field1: Default::default(),
+        }
+    }
+}
+impl Default for wire_cst_record_ffi_request_ffi_context_v_1 {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_record_ffi_request_ffi_context_v_2 {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            field0: Default::default(),
+            field1: Default::default(),
+        }
+    }
+}
+impl Default for wire_cst_record_ffi_request_ffi_context_v_2 {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
 impl NewWithNullPtr for wire_cst_record_ffi_url_list_prim_u_8_strict {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -1272,32 +1318,6 @@ impl NewWithNullPtr for wire_cst_record_u_64_out_point {
     }
 }
 impl Default for wire_cst_record_u_64_out_point {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-impl NewWithNullPtr for wire_cst_request_context_v_1 {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            request: Default::default(),
-            context_v1: Default::default(),
-        }
-    }
-}
-impl Default for wire_cst_request_context_v_1 {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-impl NewWithNullPtr for wire_cst_request_context_v_2 {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            request: Default::default(),
-            context_v2: Default::default(),
-        }
-    }
-}
-impl Default for wire_cst_request_context_v_2 {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1892,18 +1912,18 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__send__ffi_request_bui
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__send__ffi_request_context_extract_v1(
     port_: i64,
-    ptr: *mut wire_cst_ffi_request_context,
+    that: *mut wire_cst_ffi_request_context,
 ) {
-    wire__crate__api__send__ffi_request_context_extract_v1_impl(port_, ptr)
+    wire__crate__api__send__ffi_request_context_extract_v1_impl(port_, that)
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__send__ffi_request_context_extract_v2(
     port_: i64,
-    ptr: *mut wire_cst_ffi_request_context,
+    that: *mut wire_cst_ffi_request_context,
     ohttp_proxy_url: *mut wire_cst_ffi_url,
 ) {
-    wire__crate__api__send__ffi_request_context_extract_v2_impl(port_, ptr, ohttp_proxy_url)
+    wire__crate__api__send__ffi_request_context_extract_v2_impl(port_, that, ohttp_proxy_url)
 }
 
 #[no_mangle]
@@ -2062,6 +2082,24 @@ pub extern "C" fn frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpa
         StdArc::<Arc<payjoin_ffi::receive::v2::V2PayjoinProposal>>::decrement_strong_count(
             ptr as _,
         );
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+    ptr: *const std::ffi::c_void,
+) {
+    unsafe {
+        StdArc::<Arc<payjoin_ffi::send::v1::ContextV1>>::increment_strong_count(ptr as _);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_Arcpayjoin_ffisendv1ContextV1(
+    ptr: *const std::ffi::c_void,
+) {
+    unsafe {
+        StdArc::<Arc<payjoin_ffi::send::v1::ContextV1>>::decrement_strong_count(ptr as _);
     }
 }
 
@@ -2358,24 +2396,6 @@ pub extern "C" fn frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpa
 ) {
     unsafe {
         StdArc::<payjoin_ffi::receive::v2::V2UncheckedProposal>::decrement_strong_count(ptr as _);
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn frbgen_payjoin_flutter_rust_arc_increment_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(
-    ptr: *const std::ffi::c_void,
-) {
-    unsafe {
-        StdArc::<payjoin_ffi::send::v1::ContextV1>::increment_strong_count(ptr as _);
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn frbgen_payjoin_flutter_rust_arc_decrement_strong_count_RustOpaque_payjoin_ffisendv1ContextV1(
-    ptr: *const std::ffi::c_void,
-) {
-    unsafe {
-        StdArc::<payjoin_ffi::send::v1::ContextV1>::decrement_strong_count(ptr as _);
     }
 }
 
@@ -2896,6 +2916,12 @@ pub struct wire_cst_ffi_provisional_proposal {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_ffi_request {
+    ffi_url: wire_cst_ffi_url,
+    body: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_ffi_request_builder {
     field0: usize,
 }
@@ -3127,6 +3153,18 @@ pub struct wire_cst_PayjoinError_IoError {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_record_ffi_request_ffi_context_v_1 {
+    field0: wire_cst_ffi_request,
+    field1: wire_cst_ffi_context_v_1,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_record_ffi_request_ffi_context_v_2 {
+    field0: wire_cst_ffi_request,
+    field1: wire_cst_ffi_context_v_2,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_record_ffi_url_list_prim_u_8_strict {
     field0: wire_cst_ffi_url,
     field1: *mut wire_cst_list_prim_u_8_strict,
@@ -3148,18 +3186,6 @@ pub struct wire_cst_record_string_string {
 pub struct wire_cst_record_u_64_out_point {
     field0: u64,
     field1: wire_cst_out_point,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct wire_cst_request_context_v_1 {
-    request: wire_cst_record_ffi_url_list_prim_u_8_strict,
-    context_v1: wire_cst_ffi_context_v_1,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct wire_cst_request_context_v_2 {
-    request: wire_cst_record_ffi_url_list_prim_u_8_strict,
-    context_v2: wire_cst_ffi_context_v_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -1341,9 +1341,10 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_s
 
 #[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_active_session_pj_url(
+    port_: i64,
     that: *mut wire_cst_ffi_active_session,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
-    wire__crate__api__receive__ffi_active_session_pj_url_impl(that)
+) {
+    wire__crate__api__receive__ffi_active_session_pj_url_impl(port_, that)
 }
 
 #[no_mangle]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -1379,7 +1379,7 @@ fn wire__crate__api__send__ffi_request_builder_from_psbt_and_uri_impl(
 }
 fn wire__crate__api__send__ffi_request_context_extract_v1_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::send::FfiRequestContext>,
+    that: impl CstDecode<crate::api::send::FfiRequestContext>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1388,10 +1388,10 @@ fn wire__crate__api__send__ffi_request_context_extract_v1_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
-                    let output_ok = crate::api::send::FfiRequestContext::extract_v1(api_ptr)?;
+                    let output_ok = crate::api::send::FfiRequestContext::extract_v1(&api_that)?;
                     Ok(output_ok)
                 })(
                 ))
@@ -1401,7 +1401,7 @@ fn wire__crate__api__send__ffi_request_context_extract_v1_impl(
 }
 fn wire__crate__api__send__ffi_request_context_extract_v2_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::send::FfiRequestContext>,
+    that: impl CstDecode<crate::api::send::FfiRequestContext>,
     ohttp_proxy_url: impl CstDecode<crate::api::uri::FfiUrl>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
@@ -1411,12 +1411,12 @@ fn wire__crate__api__send__ffi_request_context_extract_v2_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             let api_ohttp_proxy_url = ohttp_proxy_url.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok = crate::api::send::FfiRequestContext::extract_v2(
-                        api_ptr,
+                        &api_that,
                         api_ohttp_proxy_url,
                     )?;
                     Ok(output_ok)
@@ -2024,6 +2024,14 @@ impl SseDecode for RustOpaqueNom<Arc<payjoin_ffi::receive::v2::V2PayjoinProposal
     }
 }
 
+impl SseDecode for RustOpaqueNom<Arc<payjoin_ffi::send::v1::ContextV1>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return unsafe { decode_rust_opaque_nom(inner) };
+    }
+}
+
 impl SseDecode for RustOpaqueNom<Arc<payjoin_ffi::send::v2::ContextV2>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2152,14 +2160,6 @@ impl SseDecode for RustOpaqueNom<payjoin_ffi::receive::v2::V2UncheckedProposal> 
     }
 }
 
-impl SseDecode for RustOpaqueNom<payjoin_ffi::send::v1::ContextV1> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <usize>::sse_decode(deserializer);
-        return unsafe { decode_rust_opaque_nom(inner) };
-    }
-}
-
 impl SseDecode for RustOpaqueNom<payjoin_ffi::send::v1::RequestBuilder> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2269,7 +2269,7 @@ impl SseDecode for crate::api::send::FfiContextV1 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 =
-            <RustOpaqueNom<payjoin_ffi::send::v1::ContextV1>>::sse_decode(deserializer);
+            <RustOpaqueNom<Arc<payjoin_ffi::send::v1::ContextV1>>>::sse_decode(deserializer);
         return crate::api::send::FfiContextV1(var_field0);
     }
 }
@@ -2366,6 +2366,18 @@ impl SseDecode for crate::api::receive::FfiProvisionalProposal {
                 deserializer,
             );
         return crate::api::receive::FfiProvisionalProposal(var_field0);
+    }
+}
+
+impl SseDecode for crate::api::send::FfiRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_ffiUrl = <crate::api::uri::FfiUrl>::sse_decode(deserializer);
+        let mut var_body = <Vec<u8>>::sse_decode(deserializer);
+        return crate::api::send::FfiRequest {
+            ffi_url: var_ffiUrl,
+            body: var_body,
+        };
     }
 }
 
@@ -2783,6 +2795,24 @@ impl SseDecode for crate::utils::error::PayjoinError {
     }
 }
 
+impl SseDecode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV1) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <crate::api::send::FfiRequest>::sse_decode(deserializer);
+        let mut var_field1 = <crate::api::send::FfiContextV1>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV2) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <crate::api::send::FfiRequest>::sse_decode(deserializer);
+        let mut var_field1 = <crate::api::send::FfiContextV2>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
 impl SseDecode for (crate::api::uri::FfiUrl, Vec<u8>) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2821,30 +2851,6 @@ impl SseDecode for (u64, crate::utils::types::OutPoint) {
         let mut var_field0 = <u64>::sse_decode(deserializer);
         let mut var_field1 = <crate::utils::types::OutPoint>::sse_decode(deserializer);
         return (var_field0, var_field1);
-    }
-}
-
-impl SseDecode for crate::api::send::RequestContextV1 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_request = <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_decode(deserializer);
-        let mut var_contextV1 = <crate::api::send::FfiContextV1>::sse_decode(deserializer);
-        return crate::api::send::RequestContextV1 {
-            request: var_request,
-            context_v1: var_contextV1,
-        };
-    }
-}
-
-impl SseDecode for crate::api::send::RequestContextV2 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_request = <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_decode(deserializer);
-        let mut var_contextV2 = <crate::api::send::FfiContextV2>::sse_decode(deserializer);
-        return crate::api::send::RequestContextV2 {
-            request: var_request,
-            context_v2: var_contextV2,
-        };
     }
 }
 
@@ -3130,6 +3136,24 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::receive::FfiProvisionalPropos
     for crate::api::receive::FfiProvisionalProposal
 {
     fn into_into_dart(self) -> crate::api::receive::FfiProvisionalProposal {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::send::FfiRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.ffi_url.into_into_dart().into_dart(),
+            self.body.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::send::FfiRequest {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::send::FfiRequest>
+    for crate::api::send::FfiRequest
+{
+    fn into_into_dart(self) -> crate::api::send::FfiRequest {
         self
     }
 }
@@ -3475,48 +3499,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::utils::error::PayjoinError>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::send::RequestContextV1 {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.request.into_into_dart().into_dart(),
-            self.context_v1.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::send::RequestContextV1
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::send::RequestContextV1>
-    for crate::api::send::RequestContextV1
-{
-    fn into_into_dart(self) -> crate::api::send::RequestContextV1 {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::send::RequestContextV2 {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.request.into_into_dart().into_dart(),
-            self.context_v2.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::send::RequestContextV2
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::send::RequestContextV2>
-    for crate::api::send::RequestContextV2
-{
-    fn into_into_dart(self) -> crate::api::send::RequestContextV2 {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::utils::types::TxOut {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3565,6 +3547,15 @@ impl SseEncode for std::collections::HashMap<u64, crate::utils::types::OutPoint>
 }
 
 impl SseEncode for RustOpaqueNom<Arc<payjoin_ffi::receive::v2::V2PayjoinProposal>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode for RustOpaqueNom<Arc<payjoin_ffi::send::v1::ContextV1>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         let (ptr, size) = self.sse_encode_raw();
@@ -3717,15 +3708,6 @@ impl SseEncode for RustOpaqueNom<payjoin_ffi::receive::v2::V2UncheckedProposal> 
     }
 }
 
-impl SseEncode for RustOpaqueNom<payjoin_ffi::send::v1::ContextV1> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        let (ptr, size) = self.sse_encode_raw();
-        <usize>::sse_encode(ptr, serializer);
-        <i32>::sse_encode(size, serializer);
-    }
-}
-
 impl SseEncode for RustOpaqueNom<payjoin_ffi::send::v1::RequestBuilder> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3838,7 +3820,7 @@ impl SseEncode for crate::api::receive::FfiClientResponse {
 impl SseEncode for crate::api::send::FfiContextV1 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueNom<payjoin_ffi::send::v1::ContextV1>>::sse_encode(self.0, serializer);
+        <RustOpaqueNom<Arc<payjoin_ffi::send::v1::ContextV1>>>::sse_encode(self.0, serializer);
     }
 }
 
@@ -3913,6 +3895,14 @@ impl SseEncode for crate::api::receive::FfiProvisionalProposal {
         <RustOpaqueNom<payjoin_ffi::receive::v1::ProvisionalProposal>>::sse_encode(
             self.0, serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::send::FfiRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::uri::FfiUrl>::sse_encode(self.ffi_url, serializer);
+        <Vec<u8>>::sse_encode(self.body, serializer);
     }
 }
 
@@ -4256,6 +4246,22 @@ impl SseEncode for crate::utils::error::PayjoinError {
     }
 }
 
+impl SseEncode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV1) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::send::FfiRequest>::sse_encode(self.0, serializer);
+        <crate::api::send::FfiContextV1>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV2) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::send::FfiRequest>::sse_encode(self.0, serializer);
+        <crate::api::send::FfiContextV2>::sse_encode(self.1, serializer);
+    }
+}
+
 impl SseEncode for (crate::api::uri::FfiUrl, Vec<u8>) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4290,22 +4296,6 @@ impl SseEncode for (u64, crate::utils::types::OutPoint) {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.0, serializer);
         <crate::utils::types::OutPoint>::sse_encode(self.1, serializer);
-    }
-}
-
-impl SseEncode for crate::api::send::RequestContextV1 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_encode(self.request, serializer);
-        <crate::api::send::FfiContextV1>::sse_encode(self.context_v1, serializer);
-    }
-}
-
-impl SseEncode for crate::api::send::RequestContextV2 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_encode(self.request, serializer);
-        <crate::api::send::FfiContextV2>::sse_encode(self.context_v2, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2361,18 +2361,6 @@ impl SseDecode for crate::api::receive::FfiProvisionalProposal {
     }
 }
 
-impl SseDecode for crate::api::send::FfiRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_ffiUrl = <crate::api::uri::FfiUrl>::sse_decode(deserializer);
-        let mut var_body = <Vec<u8>>::sse_decode(deserializer);
-        return crate::api::send::FfiRequest {
-            ffi_url: var_ffiUrl,
-            body: var_body,
-        };
-    }
-}
-
 impl SseDecode for crate::api::send::FfiRequestBuilder {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2787,43 +2775,34 @@ impl SseDecode for crate::utils::error::PayjoinError {
     }
 }
 
-impl SseDecode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV1) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_field0 = <crate::api::send::FfiRequest>::sse_decode(deserializer);
-        let mut var_field1 = <crate::api::send::FfiContextV1>::sse_decode(deserializer);
-        return (var_field0, var_field1);
-    }
-}
-
-impl SseDecode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV2) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_field0 = <crate::api::send::FfiRequest>::sse_decode(deserializer);
-        let mut var_field1 = <crate::api::send::FfiContextV2>::sse_decode(deserializer);
-        return (var_field0, var_field1);
-    }
-}
-
-impl SseDecode for (crate::api::uri::FfiUrl, Vec<u8>) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_field0 = <crate::api::uri::FfiUrl>::sse_decode(deserializer);
-        let mut var_field1 = <Vec<u8>>::sse_decode(deserializer);
-        return (var_field0, var_field1);
-    }
-}
-
 impl SseDecode
     for (
-        (crate::api::uri::FfiUrl, Vec<u8>),
+        crate::utils::types::Request,
         crate::utils::types::ClientResponse,
     )
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_field0 = <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_decode(deserializer);
+        let mut var_field0 = <crate::utils::types::Request>::sse_decode(deserializer);
         let mut var_field1 = <crate::utils::types::ClientResponse>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for (crate::utils::types::Request, crate::api::send::FfiContextV1) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <crate::utils::types::Request>::sse_decode(deserializer);
+        let mut var_field1 = <crate::api::send::FfiContextV1>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for (crate::utils::types::Request, crate::api::send::FfiContextV2) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <crate::utils::types::Request>::sse_decode(deserializer);
+        let mut var_field1 = <crate::api::send::FfiContextV2>::sse_decode(deserializer);
         return (var_field0, var_field1);
     }
 }
@@ -2843,6 +2822,18 @@ impl SseDecode for (u64, crate::utils::types::OutPoint) {
         let mut var_field0 = <u64>::sse_decode(deserializer);
         let mut var_field1 = <crate::utils::types::OutPoint>::sse_decode(deserializer);
         return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for crate::utils::types::Request {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_url = <crate::api::uri::FfiUrl>::sse_decode(deserializer);
+        let mut var_body = <Vec<u8>>::sse_decode(deserializer);
+        return crate::utils::types::Request {
+            url: var_url,
+            body: var_body,
+        };
     }
 }
 
@@ -3128,24 +3119,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::receive::FfiProvisionalPropos
     for crate::api::receive::FfiProvisionalProposal
 {
     fn into_into_dart(self) -> crate::api::receive::FfiProvisionalProposal {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::send::FfiRequest {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.ffi_url.into_into_dart().into_dart(),
-            self.body.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::send::FfiRequest {}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::send::FfiRequest>
-    for crate::api::send::FfiRequest
-{
-    fn into_into_dart(self) -> crate::api::send::FfiRequest {
         self
     }
 }
@@ -3487,6 +3460,24 @@ impl flutter_rust_bridge::IntoIntoDart<crate::utils::error::PayjoinError>
     for crate::utils::error::PayjoinError
 {
     fn into_into_dart(self) -> crate::utils::error::PayjoinError {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::utils::types::Request {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.url.into_into_dart().into_dart(),
+            self.body.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::utils::types::Request {}
+impl flutter_rust_bridge::IntoIntoDart<crate::utils::types::Request>
+    for crate::utils::types::Request
+{
+    fn into_into_dart(self) -> crate::utils::types::Request {
         self
     }
 }
@@ -3890,14 +3881,6 @@ impl SseEncode for crate::api::receive::FfiProvisionalProposal {
     }
 }
 
-impl SseEncode for crate::api::send::FfiRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::api::uri::FfiUrl>::sse_encode(self.ffi_url, serializer);
-        <Vec<u8>>::sse_encode(self.body, serializer);
-    }
-}
-
 impl SseEncode for crate::api::send::FfiRequestBuilder {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4238,40 +4221,32 @@ impl SseEncode for crate::utils::error::PayjoinError {
     }
 }
 
-impl SseEncode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV1) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::api::send::FfiRequest>::sse_encode(self.0, serializer);
-        <crate::api::send::FfiContextV1>::sse_encode(self.1, serializer);
-    }
-}
-
-impl SseEncode for (crate::api::send::FfiRequest, crate::api::send::FfiContextV2) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::api::send::FfiRequest>::sse_encode(self.0, serializer);
-        <crate::api::send::FfiContextV2>::sse_encode(self.1, serializer);
-    }
-}
-
-impl SseEncode for (crate::api::uri::FfiUrl, Vec<u8>) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::api::uri::FfiUrl>::sse_encode(self.0, serializer);
-        <Vec<u8>>::sse_encode(self.1, serializer);
-    }
-}
-
 impl SseEncode
     for (
-        (crate::api::uri::FfiUrl, Vec<u8>),
+        crate::utils::types::Request,
         crate::utils::types::ClientResponse,
     )
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_encode(self.0, serializer);
+        <crate::utils::types::Request>::sse_encode(self.0, serializer);
         <crate::utils::types::ClientResponse>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (crate::utils::types::Request, crate::api::send::FfiContextV1) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::utils::types::Request>::sse_encode(self.0, serializer);
+        <crate::api::send::FfiContextV1>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (crate::utils::types::Request, crate::api::send::FfiContextV2) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::utils::types::Request>::sse_encode(self.0, serializer);
+        <crate::api::send::FfiContextV2>::sse_encode(self.1, serializer);
     }
 }
 
@@ -4288,6 +4263,14 @@ impl SseEncode for (u64, crate::utils::types::OutPoint) {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.0, serializer);
         <crate::utils::types::OutPoint>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for crate::utils::types::Request {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::uri::FfiUrl>::sse_encode(self.url, serializer);
+        <Vec<u8>>::sse_encode(self.body, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -119,21 +119,25 @@ fn wire__crate__api__receive__ffi_active_session_pj_uri_builder_impl(
     )
 }
 fn wire__crate__api__receive__ffi_active_session_pj_url_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
     that: impl CstDecode<crate::api::receive::FfiActiveSession>,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "ffi_active_session_pj_url",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
             let api_that = that.cst_decode();
-            transform_result_dco::<_, _, ()>((move || {
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::api::receive::FfiActiveSession::pj_url(&api_that))?;
-                Ok(output_ok)
-            })())
+            move |context| {
+                transform_result_dco::<_, _, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::receive::FfiActiveSession::pj_url(&api_that),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -187,7 +187,7 @@ fn wire__crate__api__receive__ffi_active_session_public_key_impl(
 }
 fn wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiMaybeInputsOwned>,
+    that: impl CstDecode<crate::api::receive::FfiMaybeInputsOwned>,
     is_owned: impl CstDecode<flutter_rust_bridge::DartOpaque>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
@@ -197,7 +197,7 @@ fn wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned_impl
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             let api_is_owned =
                 decode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
                     is_owned.cst_decode(),
@@ -206,7 +206,7 @@ fn wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned_impl
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
                         crate::api::receive::FfiMaybeInputsOwned::check_inputs_not_owned(
-                            api_ptr,
+                            &api_that,
                             api_is_owned,
                         )?;
                     Ok(output_ok)
@@ -218,7 +218,7 @@ fn wire__crate__api__receive__ffi_maybe_inputs_owned_check_inputs_not_owned_impl
 }
 fn wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiMaybeInputsSeen>,
+    that: impl CstDecode<crate::api::receive::FfiMaybeInputsSeen>,
     is_known: impl CstDecode<flutter_rust_bridge::DartOpaque>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
@@ -228,14 +228,14 @@ fn wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before_
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             let api_is_known =
                 decode_DartFn_Inputs_out_point_Output_bool_AnyhowException(is_known.cst_decode());
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
                         crate::api::receive::FfiMaybeInputsSeen::check_no_inputs_seen_before(
-                            api_ptr,
+                            &api_that,
                             api_is_known,
                         )?;
                     Ok(output_ok)
@@ -247,17 +247,17 @@ fn wire__crate__api__receive__ffi_maybe_inputs_seen_check_no_inputs_seen_before_
 }
 fn wire__crate__api__receive__ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiMaybeMixedInputScripts>,
+    that: impl CstDecode<crate::api::receive::FfiMaybeMixedInputScripts>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { let api_ptr = ptr.cst_decode(); move |context|  {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "ffi_maybe_mixed_input_scripts_check_no_mixed_input_scripts", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { let api_that = that.cst_decode(); move |context|  {
                     transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move ||  {
-                         let output_ok = crate::api::receive::FfiMaybeMixedInputScripts::check_no_mixed_input_scripts(api_ptr)?;  Ok(output_ok)
+                         let output_ok = crate::api::receive::FfiMaybeMixedInputScripts::check_no_mixed_input_scripts(&api_that)?;  Ok(output_ok)
                     })())
                 } })
 }
 fn wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiOutputsUnknown>,
+    that: impl CstDecode<crate::api::receive::FfiOutputsUnknown>,
     is_receiver_output: impl CstDecode<flutter_rust_bridge::DartOpaque>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
@@ -267,7 +267,7 @@ fn wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs_impl
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             let api_is_receiver_output =
                 decode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
                     is_receiver_output.cst_decode(),
@@ -276,7 +276,7 @@ fn wire__crate__api__receive__ffi_outputs_unknown_identify_receiver_outputs_impl
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
                         crate::api::receive::FfiOutputsUnknown::identify_receiver_outputs(
-                            api_ptr,
+                            &api_that,
                             api_is_receiver_output,
                         )?;
                     Ok(output_ok)
@@ -444,9 +444,9 @@ fn wire__crate__api__receive__ffi_provisional_proposal_contribute_witness_input_
 }
 fn wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiProvisionalProposal>,
+    that: impl CstDecode<crate::api::receive::FfiProvisionalProposal>,
     process_psbt: impl CstDecode<flutter_rust_bridge::DartOpaque>,
-    min_feerate_sat_per_vb: impl CstDecode<Option<u64>>,
+    min_fee_rate_sat_per_vb: impl CstDecode<Option<u64>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -455,17 +455,17 @@ fn wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             let api_process_psbt = decode_DartFn_Inputs_String_Output_String_AnyhowException(
                 process_psbt.cst_decode(),
             );
-            let api_min_feerate_sat_per_vb = min_feerate_sat_per_vb.cst_decode();
+            let api_min_fee_rate_sat_per_vb = min_fee_rate_sat_per_vb.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok = crate::api::receive::FfiProvisionalProposal::finalize_proposal(
-                        api_ptr,
+                        &api_that,
                         api_process_psbt,
-                        api_min_feerate_sat_per_vb,
+                        api_min_fee_rate_sat_per_vb,
                     )?;
                     Ok(output_ok)
                 })(
@@ -605,7 +605,7 @@ fn wire__crate__api__receive__ffi_session_initializer_process_res_impl(
 }
 fn wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiUncheckedProposal>,
+    that: impl CstDecode<crate::api::receive::FfiUncheckedProposal>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -614,12 +614,12 @@ fn wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok(
                         crate::api::receive::FfiUncheckedProposal::assume_interactive_receiver(
-                            api_ptr,
+                            &api_that,
                         ),
                     )?;
                     Ok(output_ok)
@@ -630,7 +630,7 @@ fn wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver
 }
 fn wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiUncheckedProposal>,
+    that: impl CstDecode<crate::api::receive::FfiUncheckedProposal>,
     min_fee_rate: impl CstDecode<Option<u64>>,
     can_broadcast: impl CstDecode<flutter_rust_bridge::DartOpaque>,
 ) {
@@ -641,7 +641,7 @@ fn wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             let api_min_fee_rate = min_fee_rate.cst_decode();
             let api_can_broadcast =
                 decode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
@@ -651,7 +651,7 @@ fn wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
                         crate::api::receive::FfiUncheckedProposal::check_broadcast_suitability(
-                            api_ptr,
+                            &api_that,
                             api_min_fee_rate,
                             api_can_broadcast,
                         )?;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -78,7 +78,7 @@ fn wire__crate__api__io__fetch_ohttp_keys_impl(
 }
 fn wire__crate__api__receive__ffi_active_session_extract_req_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiActiveSession>,
+    that: impl CstDecode<crate::api::receive::FfiActiveSession>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -87,10 +87,10 @@ fn wire__crate__api__receive__ffi_active_session_extract_req_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
-                    let output_ok = crate::api::receive::FfiActiveSession::extract_req(api_ptr)?;
+                    let output_ok = crate::api::receive::FfiActiveSession::extract_req(&api_that)?;
                     Ok(output_ok)
                 })(
                 ))
@@ -99,7 +99,7 @@ fn wire__crate__api__receive__ffi_active_session_extract_req_impl(
     )
 }
 fn wire__crate__api__receive__ffi_active_session_pj_uri_builder_impl(
-    ptr: impl CstDecode<crate::api::receive::FfiActiveSession>,
+    that: impl CstDecode<crate::api::receive::FfiActiveSession>,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -108,10 +108,10 @@ fn wire__crate__api__receive__ffi_active_session_pj_uri_builder_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             transform_result_dco::<_, _, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(
-                    crate::api::receive::FfiActiveSession::pj_uri_builder(api_ptr),
+                    crate::api::receive::FfiActiveSession::pj_uri_builder(&api_that),
                 )?;
                 Ok(output_ok)
             })())
@@ -119,7 +119,7 @@ fn wire__crate__api__receive__ffi_active_session_pj_uri_builder_impl(
     )
 }
 fn wire__crate__api__receive__ffi_active_session_pj_url_impl(
-    ptr: impl CstDecode<crate::api::receive::FfiActiveSession>,
+    that: impl CstDecode<crate::api::receive::FfiActiveSession>,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -128,10 +128,10 @@ fn wire__crate__api__receive__ffi_active_session_pj_url_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             transform_result_dco::<_, _, ()>((move || {
                 let output_ok =
-                    Result::<_, ()>::Ok(crate::api::receive::FfiActiveSession::pj_url(api_ptr))?;
+                    Result::<_, ()>::Ok(crate::api::receive::FfiActiveSession::pj_url(&api_that))?;
                 Ok(output_ok)
             })())
         },
@@ -141,7 +141,7 @@ fn wire__crate__api__receive__ffi_active_session_process_res_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     that: impl CstDecode<crate::api::receive::FfiActiveSession>,
     body: impl CstDecode<Vec<u8>>,
-    ctx: impl CstDecode<crate::api::receive::FfiClientResponse>,
+    ctx: impl CstDecode<crate::utils::types::ClientResponse>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -515,7 +515,7 @@ fn wire__crate__api__receive__ffi_provisional_proposal_try_substitute_receiver_o
 }
 fn wire__crate__api__receive__ffi_session_initializer_extract_req_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiSessionInitializer>,
+    that: impl CstDecode<crate::api::receive::FfiSessionInitializer>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -524,11 +524,11 @@ fn wire__crate__api__receive__ffi_session_initializer_extract_req_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
-                        crate::api::receive::FfiSessionInitializer::extract_req(api_ptr)?;
+                        crate::api::receive::FfiSessionInitializer::extract_req(&api_that)?;
                     Ok(output_ok)
                 })(
                 ))
@@ -579,7 +579,7 @@ fn wire__crate__api__receive__ffi_session_initializer_process_res_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     that: impl CstDecode<crate::api::receive::FfiSessionInitializer>,
     body: impl CstDecode<Vec<u8>>,
-    ctx: impl CstDecode<crate::api::receive::FfiClientResponse>,
+    ctx: impl CstDecode<crate::utils::types::ClientResponse>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -843,7 +843,7 @@ fn wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v1_req_impl(
 }
 fn wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr: impl CstDecode<crate::api::receive::FfiV2PayjoinProposal>,
+    that: impl CstDecode<crate::api::receive::FfiV2PayjoinProposal>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -852,11 +852,11 @@ fn wire__crate__api__receive__ffi_v_2_payjoin_proposal_extract_v2_req_impl(
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let api_ptr = ptr.cst_decode();
+            let api_that = that.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
-                        crate::api::receive::FfiV2PayjoinProposal::extract_v2_req(api_ptr)?;
+                        crate::api::receive::FfiV2PayjoinProposal::extract_v2_req(&api_that)?;
                     Ok(output_ok)
                 })(
                 ))
@@ -916,7 +916,7 @@ fn wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     that: impl CstDecode<crate::api::receive::FfiV2PayjoinProposal>,
     res: impl CstDecode<Vec<u8>>,
-    ohttp_context: impl CstDecode<crate::api::receive::FfiClientResponse>,
+    ohttp_context: impl CstDecode<crate::utils::types::ClientResponse>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1035,7 +1035,7 @@ fn wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal_imp
     port_: flutter_rust_bridge::for_generated::MessagePort,
     that: impl CstDecode<crate::api::receive::FfiV2ProvisionalProposal>,
     process_psbt: impl CstDecode<flutter_rust_bridge::DartOpaque>,
-    min_feerate_sat_per_vb: impl CstDecode<Option<u64>>,
+    min_fee_rate_sat_per_vb: impl CstDecode<Option<u64>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1048,14 +1048,14 @@ fn wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal_imp
             let api_process_psbt = decode_DartFn_Inputs_String_Output_String_AnyhowException(
                 process_psbt.cst_decode(),
             );
-            let api_min_feerate_sat_per_vb = min_feerate_sat_per_vb.cst_decode();
+            let api_min_fee_rate_sat_per_vb = min_fee_rate_sat_per_vb.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                     let output_ok =
                         crate::api::receive::FfiV2ProvisionalProposal::finalize_proposal(
                             &api_that,
                             api_process_psbt,
-                            api_min_feerate_sat_per_vb,
+                            api_min_fee_rate_sat_per_vb,
                         )?;
                     Ok(output_ok)
                 })(
@@ -1717,24 +1717,20 @@ fn wire__crate__api__uri__ffi_uri_check_pj_supported_impl(
     )
 }
 fn wire__crate__api__uri__ffi_uri_from_str_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
     uri: impl CstDecode<String>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "ffi_uri_from_str",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
             let api_uri = uri.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
-                    let output_ok = crate::api::uri::FfiUri::from_str(api_uri)?;
-                    Ok(output_ok)
-                })(
-                ))
-            }
+            transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
+                let output_ok = crate::api::uri::FfiUri::from_str(api_uri)?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -1757,24 +1753,20 @@ fn wire__crate__api__uri__ffi_url_as_string_impl(
     )
 }
 fn wire__crate__api__uri__ffi_url_from_str_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
     url: impl CstDecode<String>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "ffi_url_from_str",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
             let api_url = url.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
-                    let output_ok = crate::api::uri::FfiUrl::from_str(api_url)?;
-                    Ok(output_ok)
-                })(
-                ))
-            }
+            transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
+                let output_ok = crate::api::uri::FfiUrl::from_str(api_url)?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -2239,6 +2231,16 @@ impl SseDecode for bool {
     }
 }
 
+impl SseDecode for crate::utils::types::ClientResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <RustOpaqueNom<
+            std::sync::Mutex<core::option::Option<ohttp::ClientResponse>>,
+        >>::sse_decode(deserializer);
+        return crate::utils::types::ClientResponse(var_field0);
+    }
+}
+
 impl SseDecode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2252,16 +2254,6 @@ impl SseDecode for crate::api::receive::FfiActiveSession {
         let mut var_field0 =
             <RustOpaqueNom<payjoin_ffi::receive::v2::ActiveSession>>::sse_decode(deserializer);
         return crate::api::receive::FfiActiveSession(var_field0);
-    }
-}
-
-impl SseDecode for crate::api::receive::FfiClientResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_field0 = <RustOpaqueNom<
-            std::sync::Mutex<core::option::Option<ohttp::ClientResponse>>,
-        >>::sse_decode(deserializer);
-        return crate::api::receive::FfiClientResponse(var_field0);
     }
 }
 
@@ -2825,13 +2817,13 @@ impl SseDecode for (crate::api::uri::FfiUrl, Vec<u8>) {
 impl SseDecode
     for (
         (crate::api::uri::FfiUrl, Vec<u8>),
-        crate::api::receive::FfiClientResponse,
+        crate::utils::types::ClientResponse,
     )
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 = <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_decode(deserializer);
-        let mut var_field1 = <crate::api::receive::FfiClientResponse>::sse_decode(deserializer);
+        let mut var_field1 = <crate::utils::types::ClientResponse>::sse_decode(deserializer);
         return (var_field0, var_field1);
     }
 }
@@ -2927,6 +2919,23 @@ fn pde_ffi_dispatcher_sync_impl(
 // Section: rust2dart
 
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::utils::types::ClientResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.0.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::utils::types::ClientResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::utils::types::ClientResponse>
+    for crate::utils::types::ClientResponse
+{
+    fn into_into_dart(self) -> crate::utils::types::ClientResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::receive::FfiActiveSession {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.0.into_into_dart().into_dart()].into_dart()
@@ -2940,23 +2949,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::receive::FfiActiveSession>
     for crate::api::receive::FfiActiveSession
 {
     fn into_into_dart(self) -> crate::api::receive::FfiActiveSession {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::receive::FfiClientResponse {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.0.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::receive::FfiClientResponse
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::receive::FfiClientResponse>
-    for crate::api::receive::FfiClientResponse
-{
-    fn into_into_dart(self) -> crate::api::receive::FfiClientResponse {
         self
     }
 }
@@ -3794,6 +3786,15 @@ impl SseEncode for bool {
     }
 }
 
+impl SseEncode for crate::utils::types::ClientResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueNom<std::sync::Mutex<core::option::Option<ohttp::ClientResponse>>>>::sse_encode(
+            self.0, serializer,
+        );
+    }
+}
+
 impl SseEncode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3805,15 +3806,6 @@ impl SseEncode for crate::api::receive::FfiActiveSession {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <RustOpaqueNom<payjoin_ffi::receive::v2::ActiveSession>>::sse_encode(self.0, serializer);
-    }
-}
-
-impl SseEncode for crate::api::receive::FfiClientResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueNom<std::sync::Mutex<core::option::Option<ohttp::ClientResponse>>>>::sse_encode(
-            self.0, serializer,
-        );
     }
 }
 
@@ -4273,13 +4265,13 @@ impl SseEncode for (crate::api::uri::FfiUrl, Vec<u8>) {
 impl SseEncode
     for (
         (crate::api::uri::FfiUrl, Vec<u8>),
-        crate::api::receive::FfiClientResponse,
+        crate::utils::types::ClientResponse,
     )
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <(crate::api::uri::FfiUrl, Vec<u8>)>::sse_encode(self.0, serializer);
-        <crate::api::receive::FfiClientResponse>::sse_encode(self.1, serializer);
+        <crate::utils::types::ClientResponse>::sse_encode(self.1, serializer);
     }
 }
 

--- a/rust/src/utils/types.rs
+++ b/rust/src/utils/types.rs
@@ -1,6 +1,8 @@
 use flutter_rust_bridge::frb;
 pub use payjoin_ffi::types::Network;
 use std::collections::HashMap;
+
+use crate::frb_generated::RustOpaque;
 // ///Represents data that needs to be transmitted to the receiver.
 // ///You need to send this request over HTTP(S) to the receiver.
 // #[derive(Clone, Debug)]
@@ -119,4 +121,20 @@ pub enum _Network {
     Bitcoin,
     ///Bitcoin’s signet
     Signet,
+}
+
+pub struct ClientResponse(
+    pub RustOpaque<std::sync::Mutex<core::option::Option<ohttp::ClientResponse>>>,
+);
+
+impl From<ClientResponse> for ohttp::ClientResponse {
+    fn from(value: ClientResponse) -> Self {
+        let mut data_guard = value.0.lock().unwrap();
+        Option::take(&mut *data_guard).expect("ClientResponse moved out of memory")
+    }
+}
+impl From<ohttp::ClientResponse> for ClientResponse {
+    fn from(value: ohttp::ClientResponse) -> Self {
+        Self(RustOpaque::new(std::sync::Mutex::new(Some(value))))
+    }
 }

--- a/rust/src/utils/types.rs
+++ b/rust/src/utils/types.rs
@@ -2,7 +2,7 @@ use flutter_rust_bridge::frb;
 pub use payjoin_ffi::types::Network;
 use std::collections::HashMap;
 
-use crate::frb_generated::RustOpaque;
+use crate::{api::uri::FfiUrl, frb_generated::RustOpaque};
 // ///Represents data that needs to be transmitted to the receiver.
 // ///You need to send this request over HTTP(S) to the receiver.
 // #[derive(Clone, Debug)]
@@ -136,5 +136,20 @@ impl From<ClientResponse> for ohttp::ClientResponse {
 impl From<ohttp::ClientResponse> for ClientResponse {
     fn from(value: ohttp::ClientResponse) -> Self {
         Self(RustOpaque::new(std::sync::Mutex::new(Some(value))))
+    }
+}
+
+#[derive(Clone)]
+pub struct Request {
+    pub url: FfiUrl,
+    pub body: Vec<u8>,
+}
+
+impl From<payjoin_ffi::types::Request> for Request {
+    fn from(value: payjoin_ffi::types::Request) -> Self {
+        Self {
+            url: (*value.url).clone().into(),
+            body: value.body,
+        }
     }
 }


### PR DESCRIPTION
This PR makes sure that the internal Ffi classes and their functions are not exposed, but only the intended public API. This way there is no confusion about which method to use and it follows the rust-payjoin naming exactly.