### PR TITLE
Upgrade to v0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.20.0]
+
 ## [0.18.0]
 Updated `flutter_rust_bridge` to `2.0.0`.
 #### APIs added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## [0.20.0]
+#### APIs added
+- Make backwards-compatible `v2` to `v1` sends possible.
+#### APIs changed
+- Removed `contributeNonWitnessInput`  from `v1` & `v2`.
+- Allow receivers to make `payjoins` out of sweep transactions ([#259](https://github.com/payjoin/rust-payjoin/pull/259)).
+- Encode &ohttp= and &exp= parameters in the &pj= URL as a fragment instead of as URI params ([#298](https://github.com/payjoin/rust-payjoin/pull/298))
 
 ## [0.18.0]
 Updated `flutter_rust_bridge` to `2.0.0`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use the `payjoin_flutter` package in your project, add it as a dependency in 
 
 ```dart
 dependencies:
-payjoin_flutter: 0.18.0
+payjoin_flutter: 0.20.0
 ```
 ### Requirements
 
@@ -26,15 +26,6 @@ this [link](https://github.com/vulpemventures/nigiri), to install it on your loc
 Once the nigiri bitcoin starts running, you need to mine a few blocks. Please refer to the following [link](https://developer.bitcoin.org/reference/rpc/generatetoaddress.html?highlight=generate)
 on how to mine blocks.
 
-Before running the integration tests, please replace following snippet in `example/integration_test/bitcoin_core_full_cycle_test.dart` with your
-nigiri bitcoin core credentials.
-
-```dart
-    // Bitcoin core credentials
-    String rpcUser = "admin1";
-    String rpcPassword = "123";
-    int rpcPort = 18443;
-```
 
 ## Running the integration tests
 Once we have set up the Bitcoin core properly in the `Regtest` network, 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ cd example
 #Run integration tests with bitcoin_core and bdk_flutter
 flutter test integration_test
 ```
-## Release status and readiness
+## References
 
-Caution, this package is an Alpha at this stage Please consider reviewing, experimenting and contributing
+[Payjoin Dev Kit](https://payjoindevkit.org/)
 
-Please review and carry out testing to ensure security and safety of funds before using in production.
+[mozilla/uniffi-rs](https://github.com/mozilla/uniffi-rs)
+
+## Release Status and Disclaimer
+
+This project is in active development and currently in its Alpha stage. **Please proceed with caution**, particularly when using real funds.
+We encourage thorough review, testing, and contributions to help improve its stability and security before considering production use.

--- a/example/integration_test/bdk_full_cycle_test.dart
+++ b/example/integration_test/bdk_full_cycle_test.dart
@@ -20,10 +20,10 @@ void main() {
       final btcClient = BtcClient("sender");
       await btcClient.loadWallet();
       final sender = BdkClient(
-          "wpkh(tprv8ZgxMBicQKsPfNH1PykMg16TAvrZgoxDnxr3eorcbhvZxyZzStwFkvqCJegr8Gbwj3GQum8QpXQPh7DGkoobpTB7YbcnUeUSKRDyX2cNN9h/84'/1'/0'/0/*)#ey7hlgpn",
+          "wpkh(tprv8ZgxMBicQKsPemPN83fE95XY5PRnDJZ6YcTHbFACvme5Rwi2RRoivdksZzrP3M61Vz13pva5LjaY1TA9JezqgzLoaNG5SXpCAcyY5w2ursV)",
           Network.regtest);
       final receiver = BdkClient(
-          "wpkh(tprv8ZgxMBicQKsPczV7D2zfMr7oUzHDhNPEuBUgrwRoWM3ijLRvhG87xYiqh9JFLPqojuhmqwMdo1oJzbe5GUpxCbDHnqyGhQa5Jg1Wt6rc9di/84'/1'/0'/0/*)#kdnuw5lq",
+          "wpkh(tprv8ZgxMBicQKsPdD2rdKcJCtGop4vqW3cmvikhzVy42iCev4E9JpeJgnHXdMKLnmAyXatvhXPi8KomgWMa316mwyirBiLXi3MMPhRV1ikfNTJ)",
           Network.regtest);
       await sender.restoreWallet();
       await receiver.restoreWallet();

--- a/example/integration_test/bitcoin_core_full_cycle_test.dart
+++ b/example/integration_test/bitcoin_core_full_cycle_test.dart
@@ -31,8 +31,8 @@ void main() {
       // Sender create a funded PSBT (not broadcast) to address with amount given in the pjUri
       debugPrint("Sender Balance: ${(await sender.getBalance()).toString()}");
       final uri = await pay_join_uri.Uri.fromStr(pjUri);
-      final address = await uri.address();
-      final amount = await uri.amount();
+      final address = uri.address();
+      final amount = uri.amount();
       final senderPsbt =
           (await sender.walletCreateFundedPsbt(amount, address, 2000))["psbt"];
       debugPrint(
@@ -41,9 +41,9 @@ void main() {
       final (provisionalProposal, ctx) =
           await payJoinLib.handlePjRequest(senderPsbt, pjUri, (e) async {
         final script = ScriptBuf(bytes: e);
-        final address = await (await Address.fromScript(
-                script: script, network: Network.regtest))
-            .asString();
+        final address =
+            (await Address.fromScript(script: script, network: Network.regtest))
+                .asString();
         return (await receiver.getAddressInfo(address))["ismine"];
       });
       final availableInputs = await receiver.listUnspent([]);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - payjoin_flutter (0.18.0)
+  - payjoin_flutter (0.20.0)
 
 DEPENDENCIES:
   - bdk_flutter (from `.symlinks/plugins/bdk_flutter/ios`)
@@ -33,8 +33,8 @@ SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  payjoin_flutter: 845f79d3e51d45e67842ee5df33ab492a1fd03cb
+  payjoin_flutter: 6397d7b698cdad6453be4949ab6aca1863f6c5e5
 
 PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,7 +115,7 @@ class _PayJoinState extends State<PayJoin> {
                     displayText = "sync complete";
                   });
                   debugPrint(
-                      "sender balance: ${(await sender.getBalance()).toString()}");
+                      "sender balance: ${(sender.getBalance()).toString()}");
                 },
                 child: Text(
                   "Sync wallets",
@@ -126,9 +126,9 @@ class _PayJoinState extends State<PayJoin> {
                 )),
             TextButton(
                 onPressed: () async {
-                  final address = (await receiver.getNewAddress()).address;
+                  final address = (receiver.getNewAddress()).address;
                   final res = await payJoinLibrary.buildPjUri(
-                      0.0083285, await address.toQrUri());
+                      0.0083285, address.toQrUri());
                   setState(() {
                     pjUri = res;
                     displayText = res;
@@ -143,12 +143,11 @@ class _PayJoinState extends State<PayJoin> {
                 )),
             TextButton(
                 onPressed: () async {
-                  final balance = await sender.getBalance();
+                  final balance = sender.getBalance();
                   debugPrint("Sender Balance: ${balance.toString()}");
                   final uri = await pay_join_uri.Uri.fromStr(pjUri);
-                  final address = await uri.address();
-                  int amount =
-                      (((await uri.amount()) ?? 0) * 100000000).toInt();
+                  final address = uri.address();
+                  int amount = (((uri.amount()) ?? 0) * 100000000).toInt();
                   final psbt = (await sender.createPsbt(address, amount, 2000));
                   debugPrint(
                     "\nOriginal sender psbt: ${psbt.toString()}",
@@ -170,9 +169,9 @@ class _PayJoinState extends State<PayJoin> {
                       .handlePjRequest(senderPsbt.toString(), pjUri, (e) async {
                     final script = ScriptBuf(bytes: e);
 
-                    return (await receiver.getAddressInfo(script));
+                    return (receiver.getAddressInfo(script));
                   });
-                  final unspent = await receiver.listUnspent();
+                  final unspent = receiver.listUnspent();
                   // Select receiver payjoin inputs.
                   Map<BigInt, common.OutPoint> candidateInputs = {
                     for (var input in unspent)

--- a/example/lib/payjoin_library.dart
+++ b/example/lib/payjoin_library.dart
@@ -39,9 +39,7 @@ class PayJoinLibrary {
       'content-length': req.body.length.toString(),
     });
     final unchecked = await v1.UncheckedProposal.fromRequest(
-        body: req.body.toList(),
-        query: (await req.url.query())!,
-        headers: headers);
+        body: req.body.toList(), query: (req.url.query())!, headers: headers);
     final provisionalProposal = await handleUnckedProposal(unchecked, isOwned);
     return (provisionalProposal, cxt);
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -417,7 +417,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.0"
+    version: "0.20.0"
   platform:
     dependency: transitive
     description:

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -60,15 +60,15 @@ typedef struct wire_cst_list_prim_u_8_strict {
   int32_t len;
 } wire_cst_list_prim_u_8_strict;
 
-typedef struct wire_cst_out_point {
-  struct wire_cst_list_prim_u_8_strict *txid;
-  uint32_t vout;
-} wire_cst_out_point;
-
 typedef struct wire_cst_tx_out {
   uint64_t value;
   struct wire_cst_list_prim_u_8_strict *script_pubkey;
 } wire_cst_tx_out;
+
+typedef struct wire_cst_out_point {
+  struct wire_cst_list_prim_u_8_strict *txid;
+  uint32_t vout;
+} wire_cst_out_point;
 
 typedef struct wire_cst_record_u_64_out_point {
   uint64_t field0;
@@ -336,11 +336,6 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_proposal_psbt
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_proposal_utxos_to_be_locked(int64_t port_,
                                                                                                struct wire_cst_ffi_payjoin_proposal *that);
 
-void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input(int64_t port_,
-                                                                                                             struct wire_cst_ffi_provisional_proposal *that,
-                                                                                                             struct wire_cst_list_prim_u_8_loose *tx,
-                                                                                                             struct wire_cst_out_point *outpoint);
-
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_contribute_witness_input(int64_t port_,
                                                                                                          struct wire_cst_ffi_provisional_proposal *that,
                                                                                                          struct wire_cst_tx_out *txo,
@@ -428,11 +423,6 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_utxos_to_be_locked(int64_t port_,
                                                                                                    struct wire_cst_ffi_v_2_payjoin_proposal *that);
-
-void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input(int64_t port_,
-                                                                                                                 struct wire_cst_ffi_v_2_provisional_proposal *that,
-                                                                                                                 struct wire_cst_list_prim_u_8_loose *tx,
-                                                                                                                 struct wire_cst_out_point *outpoint);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_witness_input(int64_t port_,
                                                                                                              struct wire_cst_ffi_v_2_provisional_proposal *that,
@@ -834,7 +824,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_proposal_owned_vouts);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_proposal_psbt);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_proposal_utxos_to_be_locked);
-    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_contribute_witness_input);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_try_preserving_privacy);
@@ -857,7 +846,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_process_res);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_psbt);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payjoin_proposal_utxos_to_be_locked);
-    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_witness_input);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_finalize_proposal);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_is_output_substitution_disabled);

--- a/ios/payjoin_flutter.podspec
+++ b/ios/payjoin_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'payjoin_flutter'
-  s.version          = '0.18.0'
+  s.version          = '0.20.0'
   s.summary          = 'A new Flutter FFI plugin project.'
   s.description      = <<-DESC
 A new Flutter FFI plugin project.

--- a/lib/receive/v1.dart
+++ b/lib/receive/v1.dart
@@ -142,16 +142,6 @@ class ProvisionalProposal extends FfiProvisionalProposal {
   }
 
   @override
-  Future<void> contributeNonWitnessInput(
-      {required List<int> tx, required common.OutPoint outpoint, hint}) {
-    try {
-      return super.contributeNonWitnessInput(tx: tx, outpoint: outpoint);
-    } on error.PayjoinError catch (e) {
-      throw mapPayjoinError(e);
-    }
-  }
-
-  @override
   Future<void> contributeWitnessInput(
       {required common.TxOut txo, required common.OutPoint outpoint, hint}) {
     try {

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -234,16 +234,6 @@ class ProvisionalProposal extends FfiV2ProvisionalProposal {
   }
 
   @override
-  Future<void> contributeNonWitnessInput(
-      {required List<int> tx, required OutPoint outpoint, hint}) {
-    try {
-      return super.contributeNonWitnessInput(tx: tx, outpoint: outpoint);
-    } on error.PayjoinError catch (e) {
-      throw mapPayjoinError(e);
-    }
-  }
-
-  @override
   Future<void> contributeWitnessInput(
       {required TxOut txo, required OutPoint outpoint, hint}) {
     try {

--- a/lib/src/generated/api/receive.dart
+++ b/lib/src/generated/api/receive.dart
@@ -195,12 +195,6 @@ class FfiProvisionalProposal {
     required this.field0,
   });
 
-  Future<void> contributeNonWitnessInput(
-          {required List<int> tx, required OutPoint outpoint}) =>
-      core.instance.api
-          .crateApiReceiveFfiProvisionalProposalContributeNonWitnessInput(
-              that: this, tx: tx, outpoint: outpoint);
-
   Future<void> contributeWitnessInput(
           {required TxOut txo, required OutPoint outpoint}) =>
       core.instance.api
@@ -499,12 +493,6 @@ class FfiV2ProvisionalProposal {
   const FfiV2ProvisionalProposal({
     required this.field0,
   });
-
-  Future<void> contributeNonWitnessInput(
-          {required List<int> tx, required OutPoint outpoint}) =>
-      core.instance.api
-          .crateApiReceiveFfiV2ProvisionalProposalContributeNonWitnessInput(
-              that: this, tx: tx, outpoint: outpoint);
 
   Future<void> contributeWitnessInput(
           {required TxOut txo, required OutPoint outpoint}) =>

--- a/lib/src/generated/api/uri.dart
+++ b/lib/src/generated/api/uri.dart
@@ -8,7 +8,7 @@ import '../lib.dart';
 import '../utils/error.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 class FfiOhttpKeys {
   final OhttpKeys field0;

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -61,7 +61,7 @@ class core extends BaseEntrypoint<coreApi, coreApiImpl, coreWire> {
   String get codegenVersion => '2.0.0';
 
   @override
-  int get rustContentHash => -1575278373;
+  int get rustContentHash => -486461789;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -122,11 +122,6 @@ abstract class coreApi extends BaseApi {
 
   Future<List<OutPoint>> crateApiReceiveFfiPayjoinProposalUtxosToBeLocked(
       {required FfiPayjoinProposal that});
-
-  Future<void> crateApiReceiveFfiProvisionalProposalContributeNonWitnessInput(
-      {required FfiProvisionalProposal that,
-      required List<int> tx,
-      required OutPoint outpoint});
 
   Future<void> crateApiReceiveFfiProvisionalProposalContributeWitnessInput(
       {required FfiProvisionalProposal that,
@@ -225,11 +220,6 @@ abstract class coreApi extends BaseApi {
 
   Future<List<OutPoint>> crateApiReceiveFfiV2PayjoinProposalUtxosToBeLocked(
       {required FfiV2PayjoinProposal that});
-
-  Future<void> crateApiReceiveFfiV2ProvisionalProposalContributeNonWitnessInput(
-      {required FfiV2ProvisionalProposal that,
-      required List<int> tx,
-      required OutPoint outpoint});
 
   Future<void> crateApiReceiveFfiV2ProvisionalProposalContributeWitnessInput(
       {required FfiV2ProvisionalProposal that,
@@ -965,38 +955,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           );
 
   @override
-  Future<void> crateApiReceiveFfiProvisionalProposalContributeNonWitnessInput(
-      {required FfiProvisionalProposal that,
-      required List<int> tx,
-      required OutPoint outpoint}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_provisional_proposal(that);
-        var arg1 = cst_encode_list_prim_u_8_loose(tx);
-        var arg2 = cst_encode_box_autoadd_out_point(outpoint);
-        return wire
-            .wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input(
-                port_, arg0, arg1, arg2);
-      },
-      codec: DcoCodec(
-        decodeSuccessData: dco_decode_unit,
-        decodeErrorData: dco_decode_payjoin_error,
-      ),
-      constMeta:
-          kCrateApiReceiveFfiProvisionalProposalContributeNonWitnessInputConstMeta,
-      argValues: [that, tx, outpoint],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiReceiveFfiProvisionalProposalContributeNonWitnessInputConstMeta =>
-          const TaskConstMeta(
-            debugName: "ffi_provisional_proposal_contribute_non_witness_input",
-            argNames: ["that", "tx", "outpoint"],
-          );
-
-  @override
   Future<void> crateApiReceiveFfiProvisionalProposalContributeWitnessInput(
       {required FfiProvisionalProposal that,
       required TxOut txo,
@@ -1674,39 +1632,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           const TaskConstMeta(
             debugName: "ffi_v_2_payjoin_proposal_utxos_to_be_locked",
             argNames: ["that"],
-          );
-
-  @override
-  Future<void> crateApiReceiveFfiV2ProvisionalProposalContributeNonWitnessInput(
-      {required FfiV2ProvisionalProposal that,
-      required List<int> tx,
-      required OutPoint outpoint}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        var arg0 = cst_encode_box_autoadd_ffi_v_2_provisional_proposal(that);
-        var arg1 = cst_encode_list_prim_u_8_loose(tx);
-        var arg2 = cst_encode_box_autoadd_out_point(outpoint);
-        return wire
-            .wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input(
-                port_, arg0, arg1, arg2);
-      },
-      codec: DcoCodec(
-        decodeSuccessData: dco_decode_unit,
-        decodeErrorData: dco_decode_payjoin_error,
-      ),
-      constMeta:
-          kCrateApiReceiveFfiV2ProvisionalProposalContributeNonWitnessInputConstMeta,
-      argValues: [that, tx, outpoint],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiReceiveFfiV2ProvisionalProposalContributeNonWitnessInputConstMeta =>
-          const TaskConstMeta(
-            debugName:
-                "ffi_v_2_provisional_proposal_contribute_non_witness_input",
-            argNames: ["that", "tx", "outpoint"],
           );
 
   @override

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -2943,39 +2943,6 @@ class coreWire implements BaseWire {
               void Function(int, ffi.Pointer<wire_cst_ffi_payjoin_proposal>)>();
 
   void
-      wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input(
-    int port_,
-    ffi.Pointer<wire_cst_ffi_provisional_proposal> that,
-    ffi.Pointer<wire_cst_list_prim_u_8_loose> tx,
-    ffi.Pointer<wire_cst_out_point> outpoint,
-  ) {
-    return _wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input(
-      port_,
-      that,
-      tx,
-      outpoint,
-    );
-  }
-
-  late final _wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_inputPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(
-                      ffi.Int64,
-                      ffi.Pointer<wire_cst_ffi_provisional_proposal>,
-                      ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                      ffi.Pointer<wire_cst_out_point>)>>(
-          'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input');
-  late final _wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input =
-      _wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_inputPtr
-          .asFunction<
-              void Function(
-                  int,
-                  ffi.Pointer<wire_cst_ffi_provisional_proposal>,
-                  ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                  ffi.Pointer<wire_cst_out_point>)>();
-
-  void
       wire__crate__api__receive__ffi_provisional_proposal_contribute_witness_input(
     int port_,
     ffi.Pointer<wire_cst_ffi_provisional_proposal> that,
@@ -3566,39 +3533,6 @@ class coreWire implements BaseWire {
           .asFunction<
               void Function(
                   int, ffi.Pointer<wire_cst_ffi_v_2_payjoin_proposal>)>();
-
-  void
-      wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input(
-    int port_,
-    ffi.Pointer<wire_cst_ffi_v_2_provisional_proposal> that,
-    ffi.Pointer<wire_cst_list_prim_u_8_loose> tx,
-    ffi.Pointer<wire_cst_out_point> outpoint,
-  ) {
-    return _wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input(
-      port_,
-      that,
-      tx,
-      outpoint,
-    );
-  }
-
-  late final _wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_inputPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(
-                      ffi.Int64,
-                      ffi.Pointer<wire_cst_ffi_v_2_provisional_proposal>,
-                      ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                      ffi.Pointer<wire_cst_out_point>)>>(
-          'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input');
-  late final _wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input =
-      _wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_inputPtr
-          .asFunction<
-              void Function(
-                  int,
-                  ffi.Pointer<wire_cst_ffi_v_2_provisional_proposal>,
-                  ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-                  ffi.Pointer<wire_cst_out_point>)>();
 
   void
       wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_witness_input(
@@ -5770,18 +5704,18 @@ final class wire_cst_list_prim_u_8_strict extends ffi.Struct {
   external int len;
 }
 
-final class wire_cst_out_point extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> txid;
-
-  @ffi.Uint32()
-  external int vout;
-}
-
 final class wire_cst_tx_out extends ffi.Struct {
   @ffi.Uint64()
   external int value;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> script_pubkey;
+}
+
+final class wire_cst_out_point extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> txid;
+
+  @ffi.Uint32()
+  external int vout;
 }
 
 final class wire_cst_record_u_64_out_point extends ffi.Struct {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: payjoin_flutter
 description: "A Flutter library for the [Payjoin Dev Kit](https://payjoindevkit.org/)"
-version: 0.18.0
+version: 0.20.0
 homepage: https://github.com/LtbLightning/payjoin-flutter
 
 environment:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -369,11 +369,11 @@ dependencies = [
 
 [[package]]
 name = "bip21"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9532c632b068e45a478f5e309126b6e2ec1dbf0bbd327b73836f33d9a43ede"
+checksum = "ebe7a7f5928d264879d5b65eb18a72ea1890c57f22d62ee2eba93f207a6a020b"
 dependencies = [
- "bitcoin 0.30.2",
+ "bitcoin 0.32.2",
  "percent-encoding-rfc3986",
 ]
 
@@ -410,6 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32 0.11.0",
  "bitcoin-internals 0.3.0",
  "bitcoin-io",
@@ -1773,12 +1774,13 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "payjoin"
-version = "0.19.0"
-source = "git+https://github.com/payjoin/rust-payjoin?rev=941a6798f52f60d72061fc0a02b5b42146321453#941a6798f52f60d72061fc0a02b5b42146321453"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf485245549b366884e295426755ce649d924762f676c1cc00e12e21501884a3"
 dependencies = [
  "bhttp",
  "bip21",
- "bitcoin 0.30.2",
+ "bitcoin 0.32.2",
  "chacha20poly1305 0.10.1",
  "http",
  "log",
@@ -1792,8 +1794,8 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.18.0"
-source = "git+https://github.com/LtbLightning/payjoin-ffi?branch=main#f5d26ac3ff1a857ecdd36aecb8747b5d6124aede"
+version = "0.20.0"
+source = "git+https://github.com/nucode-Tech/payjoin-ffi?branch=v0.20.0#e1538f8aac8981ba160f8f8705c3eb2a96d9f8eb"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -1806,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin_flutter"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin_flutter"
-version = "0.18.0"
+version = "0.20.0"
 edition = "2021"
 
 [lib]
@@ -16,7 +16,7 @@ bitcoincore-rpc = "0.19.0"
 anyhow = "1.0.68"
 [dependencies]
 ohttp = { version = "0.5.1" }
-payjoin_ffi = { git = "https://github.com/LtbLightning/payjoin-ffi", branch = "main" }
+payjoin_ffi = { git = "https://github.com/nucode-Tech/payjoin-ffi", branch = "v0.20.0" }
 flutter_rust_bridge = "=2.0.0"
 anyhow = "1.0.68"
 tokio = "1.36.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ bitcoincore-rpc = "0.19.0"
 anyhow = "1.0.68"
 [dependencies]
 ohttp = { version = "0.5.1" }
-payjoin_ffi = { git = "https://github.com/nucode-Tech/payjoin-ffi", branch = "v0.20.0" }
+payjoin_ffi = { git = "https://github.com/nucode-Tech/payjoin-ffi", branch = "main" }
 flutter_rust_bridge = "=2.0.0"
 anyhow = "1.0.68"
 tokio = "1.36.0"

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-07-24"
+components = ["rustfmt"]

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,0 +1,77 @@
+## This is copied from https://github.com/rust-bitcoin/rust-bitcoin/blob/master/rustfmt.toml
+
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+indent_style = "Block"
+
+max_width = 100 # This is number of characters.
+# `use_small_heuristics` is ignored if the granular width config values are explicitly set.
+use_small_heuristics = "Max" # "Max" == All granular width settings same as `max_width`.
+# # Granular width configuration settings. These are percentages of `max_width`.
+# fn_call_width = 60
+# attr_fn_like_width = 70
+# struct_lit_width = 18
+# struct_variant_width = 35
+# array_width = 60
+# chain_width = 60
+# single_line_if_else_max_width = 50
+
+wrap_comments = false
+format_code_in_doc_comments = true
+comment_width = 100                    # Default 80
+normalize_comments = false
+normalize_doc_attributes = false
+format_strings = false
+format_macro_matchers = false
+format_macro_bodies = true
+hex_literal_case = "Preserve"
+empty_item_single_line = true
+struct_lit_single_line = true
+fn_single_line = false                  # Default false
+where_single_line = false
+imports_indent = "Block"
+imports_layout = "Mixed"
+imports_granularity = "Module"         # Default "Preserve"
+group_imports = "StdExternalCrate"     # Default "Preserve"
+reorder_imports = true
+reorder_modules = true
+reorder_impl_items = false
+type_punctuation_density = "Wide"
+space_before_colon = false
+space_after_colon = true
+spaces_around_ranges = false
+binop_separator = "Front"
+remove_nested_parens = true
+combine_control_expr = true
+overflow_delimited_expr = false
+struct_field_align_threshold = 0
+enum_discrim_align_threshold = 0
+match_arm_leading_pipes = "Never"
+force_multiline_blocks = true
+fn_params_layout = "Tall"
+brace_style = "SameLineWhere"
+control_brace_style = "AlwaysSameLine"
+trailing_semicolon = true
+trailing_comma = "Vertical"
+match_block_trailing_comma = false
+blank_lines_upper_bound = 1
+blank_lines_lower_bound = 0
+edition = "2018"
+version = "One"
+inline_attribute_width = 0
+format_generated_files = true
+merge_derives = true
+use_try_shorthand = false
+use_field_init_shorthand = false
+force_explicit_abi = true
+condense_wildcard_suffixes = false
+color = "Auto"
+unstable_features = false
+disable_all_formatting = false
+skip_children = false
+show_parse_errors = true
+error_on_line_overflow = false
+error_on_unformatted = false
+emit_mode = "Files"
+make_backup = false

--- a/rust/src/api/send.rs
+++ b/rust/src/api/send.rs
@@ -1,9 +1,9 @@
-use crate::api::uri::{FfiPjUri, FfiUrl};
-use crate::frb_generated::RustOpaque;
-use crate::utils::types::Request;
 use std::sync::Arc;
 
 use super::receive::PayjoinError;
+use crate::api::uri::{FfiPjUri, FfiUrl};
+use crate::frb_generated::RustOpaque;
+use crate::utils::types::Request;
 
 pub struct FfiRequestBuilder(pub RustOpaque<payjoin_ffi::send::v1::RequestBuilder>);
 impl From<payjoin_ffi::send::v1::RequestBuilder> for FfiRequestBuilder {
@@ -17,18 +17,13 @@ impl FfiRequestBuilder {
         psbt_base64: String,
         pj_uri: FfiPjUri,
     ) -> anyhow::Result<FfiRequestBuilder, PayjoinError> {
-        match payjoin_ffi::send::v1::RequestBuilder::from_psbt_and_uri(
-            psbt_base64,
-            Arc::new((*pj_uri.0).clone()),
-        ) {
+        match payjoin_ffi::send::v1::RequestBuilder::from_psbt_and_uri(psbt_base64, pj_uri.into()) {
             Ok(e) => Ok(e.into()),
             Err(e) => Err(e.into()),
         }
     }
     pub fn always_disable_output_substitution(&self, disable: bool) -> FfiRequestBuilder {
-        (*self.0.clone().always_disable_output_substitution(disable))
-            .clone()
-            .into()
+        (*self.0.clone().always_disable_output_substitution(disable)).clone().into()
     }
     pub fn build_recommended(
         &self,
@@ -122,10 +117,7 @@ pub struct FfiRequestContextV2 {
 impl From<payjoin_ffi::send::v1::RequestContextV2> for FfiRequestContextV2 {
     fn from(value: payjoin_ffi::send::v1::RequestContextV2) -> Self {
         Self {
-            request: Request {
-                url: (*value.request.url).clone().into(),
-                body: value.request.body,
-            },
+            request: Request { url: (*value.request.url).clone().into(), body: value.request.body },
             context_v2: value.context_v2.into(),
         }
     }

--- a/rust/src/api/uri.rs
+++ b/rust/src/api/uri.rs
@@ -1,6 +1,7 @@
+use flutter_rust_bridge::frb;
+
 use crate::frb_generated::RustOpaque;
 use crate::utils::error::PayjoinError;
-use flutter_rust_bridge::frb;
 
 #[derive(Debug, Clone)]
 pub struct FfiUrl(pub RustOpaque<payjoin_ffi::uri::Url>);
@@ -70,9 +71,7 @@ pub struct FfiPjUriBuilder {
 
 impl From<payjoin_ffi::uri::PjUriBuilder> for FfiPjUriBuilder {
     fn from(value: payjoin_ffi::uri::PjUriBuilder) -> Self {
-        Self {
-            internal: RustOpaque::new(value),
-        }
+        Self { internal: RustOpaque::new(value) }
     }
 }
 
@@ -81,17 +80,16 @@ impl FfiPjUriBuilder {
         address: String,
         pj: FfiUrl,
         ohttp_keys: Option<FfiOhttpKeys>,
-        expiry: Option<u64>
+        expiry: Option<u64>,
     ) -> Result<Self, PayjoinError> {
-        payjoin_ffi::uri::PjUriBuilder
-            ::new(
-                address,
-                (*pj.0).clone(),
-                ohttp_keys.map(|e| (*e.0).clone()),
-                expiry
-            )
-            .map_err(|e| e.into())
-            .map(|e| e.into())
+        payjoin_ffi::uri::PjUriBuilder::new(
+            address,
+            (*pj.0).clone(),
+            ohttp_keys.map(|e| (*e.0).clone()),
+            expiry,
+        )
+        .map_err(|e| e.into())
+        .map(|e| e.into())
     }
     ///Accepts the amount you want to receive in sats and sets it in btc.
     #[frb(sync)]
@@ -132,10 +130,7 @@ impl FfiUri {
     pub fn from_str(uri: String) -> anyhow::Result<FfiUri, PayjoinError> {
         match payjoin_ffi::uri::Uri::from_str(uri) {
             Ok(e) => Ok(e.into()),
-            Err(e) =>
-                Err(PayjoinError::PjParseError {
-                    message: e.to_string(),
-                }),
+            Err(e) => Err(PayjoinError::PjParseError { message: e.to_string() }),
         }
     }
     #[frb(sync)]
@@ -153,10 +148,7 @@ impl FfiUri {
     }
     #[frb(sync)]
     pub fn check_pj_supported(&self) -> Result<FfiPjUri, payjoin_ffi::error::PayjoinError> {
-        self.0
-            .check_pj_supported()
-            .map(|e| e.into())
-            .map_err(|e| e.into())
+        self.0.check_pj_supported().map(|e| e.into()).map_err(|e| e.into())
     }
 }
 pub struct FfiOhttpKeys(pub RustOpaque<payjoin_ffi::types::OhttpKeys>);
@@ -174,15 +166,12 @@ impl From<payjoin_ffi::types::OhttpKeys> for FfiOhttpKeys {
 
 impl FfiOhttpKeys {
     pub fn decode(bytes: Vec<u8>) -> Result<Self, PayjoinError> {
-        payjoin_ffi::types::OhttpKeys
-            ::decode(bytes)
-            .map(|e| e.into())
-            .map_err(|e| e.into())
+        payjoin_ffi::types::OhttpKeys::decode(bytes).map(|e| e.into()).map_err(|e| e.into())
     }
 }
 #[cfg(test)]
 mod tests {
-    use crate::api::uri::{ FfiPjUriBuilder, FfiUrl };
+    use crate::api::uri::{FfiPjUriBuilder, FfiUrl};
 
     #[test]
     fn test_ffi_builder() {
@@ -198,8 +187,9 @@ mod tests {
                     address.to_string(),
                     FfiUrl::from_str(pj.to_string()).unwrap(),
                     None,
-                    None
-                ).unwrap();
+                    None,
+                )
+                .unwrap();
                 let uri = builder
                     .amount(1)
                     .message("message".to_string())
@@ -213,8 +203,7 @@ mod tests {
                     uri.as_string(),
                     format!(
                         "bitcoin:{}?amount=0.00000001&label=label&message=message&pj={}&pjos=1",
-                        expected_address,
-                        pj
+                        expected_address, pj
                     )
                 );
             }

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -3,11 +3,12 @@
 
 // Section: imports
 
-use super::*;
-use crate::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
+
+use super::*;
+use crate::*;
 
 // Section: boilerplate
 
@@ -524,9 +525,7 @@ impl CstDecode<crate::api::uri::FfiPjUri> for wire_cst_ffi_pj_uri {
 impl CstDecode<crate::api::uri::FfiPjUriBuilder> for wire_cst_ffi_pj_uri_builder {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::uri::FfiPjUriBuilder {
-        crate::api::uri::FfiPjUriBuilder {
-            internal: self.internal.cst_decode(),
-        }
+        crate::api::uri::FfiPjUriBuilder { internal: self.internal.cst_decode() }
     }
 }
 impl CstDecode<crate::api::receive::FfiProvisionalProposal> for wire_cst_ffi_provisional_proposal {
@@ -622,9 +621,7 @@ impl CstDecode<crate::api::receive::FfiV2UncheckedProposal>
 impl CstDecode<crate::utils::types::Headers> for wire_cst_headers {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::utils::types::Headers {
-        crate::utils::types::Headers {
-            map: self.map.cst_decode(),
-        }
+        crate::utils::types::Headers { map: self.map.cst_decode() }
     }
 }
 impl CstDecode<Vec<crate::utils::types::OutPoint>> for *mut wire_cst_list_out_point {
@@ -689,10 +686,7 @@ impl CstDecode<Vec<(u64, crate::utils::types::OutPoint)>>
 impl CstDecode<crate::utils::types::OutPoint> for wire_cst_out_point {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::utils::types::OutPoint {
-        crate::utils::types::OutPoint {
-            txid: self.txid.cst_decode(),
-            vout: self.vout.cst_decode(),
-        }
+        crate::utils::types::OutPoint { txid: self.txid.cst_decode(), vout: self.vout.cst_decode() }
     }
 }
 impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
@@ -743,9 +737,7 @@ impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
             }
             7 => {
                 let ans = unsafe { self.kind.ServerError };
-                crate::utils::error::PayjoinError::ServerError {
-                    message: ans.message.cst_decode(),
-                }
+                crate::utils::error::PayjoinError::ServerError { message: ans.message.cst_decode() }
             }
             8 => {
                 let ans = unsafe { self.kind.SelectionError };
@@ -779,9 +771,7 @@ impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
             }
             13 => {
                 let ans = unsafe { self.kind.V2Error };
-                crate::utils::error::PayjoinError::V2Error {
-                    message: ans.message.cst_decode(),
-                }
+                crate::utils::error::PayjoinError::V2Error { message: ans.message.cst_decode() }
             }
             14 => {
                 let ans = unsafe { self.kind.UnexpectedError };
@@ -791,39 +781,25 @@ impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
             }
             15 => {
                 let ans = unsafe { self.kind.OhttpError };
-                crate::utils::error::PayjoinError::OhttpError {
-                    message: ans.message.cst_decode(),
-                }
+                crate::utils::error::PayjoinError::OhttpError { message: ans.message.cst_decode() }
             }
             16 => {
                 let ans = unsafe { self.kind.UrlError };
-                crate::utils::error::PayjoinError::UrlError {
-                    message: ans.message.cst_decode(),
-                }
+                crate::utils::error::PayjoinError::UrlError { message: ans.message.cst_decode() }
             }
             17 => {
                 let ans = unsafe { self.kind.IoError };
-                crate::utils::error::PayjoinError::IoError {
-                    message: ans.message.cst_decode(),
-                }
+                crate::utils::error::PayjoinError::IoError { message: ans.message.cst_decode() }
             }
             _ => unreachable!(),
         }
     }
 }
-impl
-    CstDecode<(
-        crate::utils::types::Request,
-        crate::utils::types::ClientResponse,
-    )> for wire_cst_record_request_client_response
+impl CstDecode<(crate::utils::types::Request, crate::utils::types::ClientResponse)>
+    for wire_cst_record_request_client_response
 {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(
-        self,
-    ) -> (
-        crate::utils::types::Request,
-        crate::utils::types::ClientResponse,
-    ) {
+    fn cst_decode(self) -> (crate::utils::types::Request, crate::utils::types::ClientResponse) {
         (self.field0.cst_decode(), self.field1.cst_decode())
     }
 }
@@ -858,10 +834,7 @@ impl CstDecode<(u64, crate::utils::types::OutPoint)> for wire_cst_record_u_64_ou
 impl CstDecode<crate::utils::types::Request> for wire_cst_request {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::utils::types::Request {
-        crate::utils::types::Request {
-            url: self.url.cst_decode(),
-            body: self.body.cst_decode(),
-        }
+        crate::utils::types::Request { url: self.url.cst_decode(), body: self.body.cst_decode() }
     }
 }
 impl CstDecode<crate::utils::types::TxOut> for wire_cst_tx_out {
@@ -875,9 +848,7 @@ impl CstDecode<crate::utils::types::TxOut> for wire_cst_tx_out {
 }
 impl NewWithNullPtr for wire_cst_client_response {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_client_response {
@@ -887,9 +858,7 @@ impl Default for wire_cst_client_response {
 }
 impl NewWithNullPtr for wire_cst_ffi_active_session {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_active_session {
@@ -899,9 +868,7 @@ impl Default for wire_cst_ffi_active_session {
 }
 impl NewWithNullPtr for wire_cst_ffi_context_v_1 {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_context_v_1 {
@@ -911,9 +878,7 @@ impl Default for wire_cst_ffi_context_v_1 {
 }
 impl NewWithNullPtr for wire_cst_ffi_context_v_2 {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_context_v_2 {
@@ -923,9 +888,7 @@ impl Default for wire_cst_ffi_context_v_2 {
 }
 impl NewWithNullPtr for wire_cst_ffi_maybe_inputs_owned {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_maybe_inputs_owned {
@@ -935,9 +898,7 @@ impl Default for wire_cst_ffi_maybe_inputs_owned {
 }
 impl NewWithNullPtr for wire_cst_ffi_maybe_inputs_seen {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_maybe_inputs_seen {
@@ -947,9 +908,7 @@ impl Default for wire_cst_ffi_maybe_inputs_seen {
 }
 impl NewWithNullPtr for wire_cst_ffi_maybe_mixed_input_scripts {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_maybe_mixed_input_scripts {
@@ -959,9 +918,7 @@ impl Default for wire_cst_ffi_maybe_mixed_input_scripts {
 }
 impl NewWithNullPtr for wire_cst_ffi_ohttp_keys {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_ohttp_keys {
@@ -971,9 +928,7 @@ impl Default for wire_cst_ffi_ohttp_keys {
 }
 impl NewWithNullPtr for wire_cst_ffi_outputs_unknown {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_outputs_unknown {
@@ -983,9 +938,7 @@ impl Default for wire_cst_ffi_outputs_unknown {
 }
 impl NewWithNullPtr for wire_cst_ffi_payjoin_proposal {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_payjoin_proposal {
@@ -995,9 +948,7 @@ impl Default for wire_cst_ffi_payjoin_proposal {
 }
 impl NewWithNullPtr for wire_cst_ffi_pj_uri {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_pj_uri {
@@ -1007,9 +958,7 @@ impl Default for wire_cst_ffi_pj_uri {
 }
 impl NewWithNullPtr for wire_cst_ffi_pj_uri_builder {
     fn new_with_null_ptr() -> Self {
-        Self {
-            internal: Default::default(),
-        }
+        Self { internal: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_pj_uri_builder {
@@ -1019,9 +968,7 @@ impl Default for wire_cst_ffi_pj_uri_builder {
 }
 impl NewWithNullPtr for wire_cst_ffi_provisional_proposal {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_provisional_proposal {
@@ -1031,9 +978,7 @@ impl Default for wire_cst_ffi_provisional_proposal {
 }
 impl NewWithNullPtr for wire_cst_ffi_request_builder {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_request_builder {
@@ -1043,9 +988,7 @@ impl Default for wire_cst_ffi_request_builder {
 }
 impl NewWithNullPtr for wire_cst_ffi_request_context {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_request_context {
@@ -1055,9 +998,7 @@ impl Default for wire_cst_ffi_request_context {
 }
 impl NewWithNullPtr for wire_cst_ffi_session_initializer {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_session_initializer {
@@ -1067,9 +1008,7 @@ impl Default for wire_cst_ffi_session_initializer {
 }
 impl NewWithNullPtr for wire_cst_ffi_unchecked_proposal {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_unchecked_proposal {
@@ -1079,9 +1018,7 @@ impl Default for wire_cst_ffi_unchecked_proposal {
 }
 impl NewWithNullPtr for wire_cst_ffi_uri {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_uri {
@@ -1091,9 +1028,7 @@ impl Default for wire_cst_ffi_uri {
 }
 impl NewWithNullPtr for wire_cst_ffi_url {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_url {
@@ -1103,9 +1038,7 @@ impl Default for wire_cst_ffi_url {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_maybe_inputs_owned {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_maybe_inputs_owned {
@@ -1115,9 +1048,7 @@ impl Default for wire_cst_ffi_v_2_maybe_inputs_owned {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_maybe_inputs_seen {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_maybe_inputs_seen {
@@ -1127,9 +1058,7 @@ impl Default for wire_cst_ffi_v_2_maybe_inputs_seen {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_maybe_mixed_input_scripts {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_maybe_mixed_input_scripts {
@@ -1139,9 +1068,7 @@ impl Default for wire_cst_ffi_v_2_maybe_mixed_input_scripts {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_outputs_unknown {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_outputs_unknown {
@@ -1151,9 +1078,7 @@ impl Default for wire_cst_ffi_v_2_outputs_unknown {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_payjoin_proposal {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_payjoin_proposal {
@@ -1163,9 +1088,7 @@ impl Default for wire_cst_ffi_v_2_payjoin_proposal {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_provisional_proposal {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_provisional_proposal {
@@ -1175,9 +1098,7 @@ impl Default for wire_cst_ffi_v_2_provisional_proposal {
 }
 impl NewWithNullPtr for wire_cst_ffi_v_2_unchecked_proposal {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-        }
+        Self { field0: Default::default() }
     }
 }
 impl Default for wire_cst_ffi_v_2_unchecked_proposal {
@@ -1187,9 +1108,7 @@ impl Default for wire_cst_ffi_v_2_unchecked_proposal {
 }
 impl NewWithNullPtr for wire_cst_headers {
     fn new_with_null_ptr() -> Self {
-        Self {
-            map: core::ptr::null_mut(),
-        }
+        Self { map: core::ptr::null_mut() }
     }
 }
 impl Default for wire_cst_headers {
@@ -1199,10 +1118,7 @@ impl Default for wire_cst_headers {
 }
 impl NewWithNullPtr for wire_cst_out_point {
     fn new_with_null_ptr() -> Self {
-        Self {
-            txid: core::ptr::null_mut(),
-            vout: Default::default(),
-        }
+        Self { txid: core::ptr::null_mut(), vout: Default::default() }
     }
 }
 impl Default for wire_cst_out_point {
@@ -1212,10 +1128,7 @@ impl Default for wire_cst_out_point {
 }
 impl NewWithNullPtr for wire_cst_payjoin_error {
     fn new_with_null_ptr() -> Self {
-        Self {
-            tag: -1,
-            kind: PayjoinErrorKind { nil__: () },
-        }
+        Self { tag: -1, kind: PayjoinErrorKind { nil__: () } }
     }
 }
 impl Default for wire_cst_payjoin_error {
@@ -1225,10 +1138,7 @@ impl Default for wire_cst_payjoin_error {
 }
 impl NewWithNullPtr for wire_cst_record_request_client_response {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-            field1: Default::default(),
-        }
+        Self { field0: Default::default(), field1: Default::default() }
     }
 }
 impl Default for wire_cst_record_request_client_response {
@@ -1238,10 +1148,7 @@ impl Default for wire_cst_record_request_client_response {
 }
 impl NewWithNullPtr for wire_cst_record_request_ffi_context_v_1 {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-            field1: Default::default(),
-        }
+        Self { field0: Default::default(), field1: Default::default() }
     }
 }
 impl Default for wire_cst_record_request_ffi_context_v_1 {
@@ -1251,10 +1158,7 @@ impl Default for wire_cst_record_request_ffi_context_v_1 {
 }
 impl NewWithNullPtr for wire_cst_record_request_ffi_context_v_2 {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-            field1: Default::default(),
-        }
+        Self { field0: Default::default(), field1: Default::default() }
     }
 }
 impl Default for wire_cst_record_request_ffi_context_v_2 {
@@ -1264,10 +1168,7 @@ impl Default for wire_cst_record_request_ffi_context_v_2 {
 }
 impl NewWithNullPtr for wire_cst_record_string_string {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: core::ptr::null_mut(),
-            field1: core::ptr::null_mut(),
-        }
+        Self { field0: core::ptr::null_mut(), field1: core::ptr::null_mut() }
     }
 }
 impl Default for wire_cst_record_string_string {
@@ -1277,10 +1178,7 @@ impl Default for wire_cst_record_string_string {
 }
 impl NewWithNullPtr for wire_cst_record_u_64_out_point {
     fn new_with_null_ptr() -> Self {
-        Self {
-            field0: Default::default(),
-            field1: Default::default(),
-        }
+        Self { field0: Default::default(), field1: Default::default() }
     }
 }
 impl Default for wire_cst_record_u_64_out_point {
@@ -1290,10 +1188,7 @@ impl Default for wire_cst_record_u_64_out_point {
 }
 impl NewWithNullPtr for wire_cst_request {
     fn new_with_null_ptr() -> Self {
-        Self {
-            url: Default::default(),
-            body: core::ptr::null_mut(),
-        }
+        Self { url: Default::default(), body: core::ptr::null_mut() }
     }
 }
 impl Default for wire_cst_request {
@@ -1303,10 +1198,7 @@ impl Default for wire_cst_request {
 }
 impl NewWithNullPtr for wire_cst_tx_out {
     fn new_with_null_ptr() -> Self {
-        Self {
-            value: Default::default(),
-            script_pubkey: core::ptr::null_mut(),
-        }
+        Self { value: Default::default(), script_pubkey: core::ptr::null_mut() }
     }
 }
 impl Default for wire_cst_tx_out {
@@ -1441,18 +1333,6 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_payjoin_
     that: *mut wire_cst_ffi_payjoin_proposal,
 ) {
     wire__crate__api__receive__ffi_payjoin_proposal_utxos_to_be_locked_impl(port_, that)
-}
-
-#[no_mangle]
-pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input(
-    port_: i64,
-    that: *mut wire_cst_ffi_provisional_proposal,
-    tx: *mut wire_cst_list_prim_u_8_loose,
-    outpoint: *mut wire_cst_out_point,
-) {
-    wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input_impl(
-        port_, that, tx, outpoint,
-    )
 }
 
 #[no_mangle]
@@ -1698,18 +1578,6 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_payj
     that: *mut wire_cst_ffi_v_2_payjoin_proposal,
 ) {
     wire__crate__api__receive__ffi_v_2_payjoin_proposal_utxos_to_be_locked_impl(port_, that)
-}
-
-#[no_mangle]
-pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input(
-    port_: i64,
-    that: *mut wire_cst_ffi_v_2_provisional_proposal,
-    tx: *mut wire_cst_list_prim_u_8_loose,
-    outpoint: *mut wire_cst_out_point,
-) {
-    wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input_impl(
-        port_, that, tx, outpoint,
-    )
 }
 
 #[no_mangle]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -25,10 +25,11 @@
 
 // Section: imports
 
-use crate::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
+
+use crate::*;
 
 // Section: boilerplate
 
@@ -38,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1575278373;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -486461789;
 
 // Section: executor
 
@@ -60,18 +61,22 @@ fn wire__crate__api__io__fetch_ohttp_keys_impl(
         move || {
             let api_ohttp_relay = ohttp_relay.cst_decode();
             let api_payjoin_directory = payjoin_directory.cst_decode();
-            move |context| async move {
-                transform_result_dco::<_, _, crate::utils::error::PayjoinError>(
-                    (move || async move {
-                        let output_ok = crate::api::io::fetch_ohttp_keys(
-                            api_ohttp_relay,
-                            api_payjoin_directory,
-                        )
-                        .await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
+            move |context| {
+                async move {
+                    transform_result_dco::<_, _, crate::utils::error::PayjoinError>(
+                        (move || {
+                            async move {
+                                let output_ok = crate::api::io::fetch_ohttp_keys(
+                                    api_ohttp_relay,
+                                    api_payjoin_directory,
+                                )
+                                .await?;
+                                Ok(output_ok)
+                            }
+                        })()
+                        .await,
+                    )
+                }
             }
         },
     )
@@ -380,37 +385,6 @@ fn wire__crate__api__receive__ffi_payjoin_proposal_utxos_to_be_locked_impl(
                     )?;
                     Ok(output_ok)
                 })())
-            }
-        },
-    )
-}
-fn wire__crate__api__receive__ffi_provisional_proposal_contribute_non_witness_input_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    that: impl CstDecode<crate::api::receive::FfiProvisionalProposal>,
-    tx: impl CstDecode<Vec<u8>>,
-    outpoint: impl CstDecode<crate::utils::types::OutPoint>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "ffi_provisional_proposal_contribute_non_witness_input",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_that = that.cst_decode();
-            let api_tx = tx.cst_decode();
-            let api_outpoint = outpoint.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
-                    let output_ok =
-                        crate::api::receive::FfiProvisionalProposal::contribute_non_witness_input(
-                            &api_that,
-                            api_tx,
-                            api_outpoint,
-                        )?;
-                    Ok(output_ok)
-                })(
-                ))
             }
         },
     )
@@ -991,18 +965,6 @@ fn wire__crate__api__receive__ffi_v_2_payjoin_proposal_utxos_to_be_locked_impl(
             }
         },
     )
-}
-fn wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_non_witness_input_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    that: impl CstDecode<crate::api::receive::FfiV2ProvisionalProposal>,
-    tx: impl CstDecode<Vec<u8>>,
-    outpoint: impl CstDecode<crate::utils::types::OutPoint>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "ffi_v_2_provisional_proposal_contribute_non_witness_input", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { let api_that = that.cst_decode();let api_tx = tx.cst_decode();let api_outpoint = outpoint.cst_decode(); move |context|  {
-                    transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move ||  {
-                         let output_ok = crate::api::receive::FfiV2ProvisionalProposal::contribute_non_witness_input(&api_that, api_tx, api_outpoint)?;  Ok(output_ok)
-                    })())
-                } })
 }
 fn wire__crate__api__receive__ffi_v_2_provisional_proposal_contribute_witness_input_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
@@ -1802,17 +1764,19 @@ fn decode_DartFn_Inputs_String_Output_String_AnyhowException(
 
     async fn body(dart_opaque: flutter_rust_bridge::DartOpaque, arg0: String) -> String {
         let args = vec![arg0.into_into_dart().into_dart()];
-        let message = FLUTTER_RUST_BRIDGE_HANDLER
-            .dart_fn_invoke(dart_opaque, args)
-            .await;
+        let message = FLUTTER_RUST_BRIDGE_HANDLER.dart_fn_invoke(dart_opaque, args).await;
 
         let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
         let action = deserializer.cursor.read_u8().unwrap();
         let ans = match action {
             0 => std::result::Result::Ok(<String>::sse_decode(&mut deserializer)),
-            1 => std::result::Result::Err(
-                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
-            ),
+            1 => {
+                std::result::Result::Err(
+                    <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(
+                        &mut deserializer,
+                    ),
+                )
+            }
             _ => unreachable!(),
         };
         deserializer.end();
@@ -1834,17 +1798,19 @@ fn decode_DartFn_Inputs__Output_list_prim_u_8_strict_AnyhowException(
 
     async fn body(dart_opaque: flutter_rust_bridge::DartOpaque) -> Vec<u8> {
         let args = vec![];
-        let message = FLUTTER_RUST_BRIDGE_HANDLER
-            .dart_fn_invoke(dart_opaque, args)
-            .await;
+        let message = FLUTTER_RUST_BRIDGE_HANDLER.dart_fn_invoke(dart_opaque, args).await;
 
         let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
         let action = deserializer.cursor.read_u8().unwrap();
         let ans = match action {
             0 => std::result::Result::Ok(<Vec<u8>>::sse_decode(&mut deserializer)),
-            1 => std::result::Result::Err(
-                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
-            ),
+            1 => {
+                std::result::Result::Err(
+                    <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(
+                        &mut deserializer,
+                    ),
+                )
+            }
             _ => unreachable!(),
         };
         deserializer.end();
@@ -1863,17 +1829,19 @@ fn decode_DartFn_Inputs_list_prim_u_8_strict_Output_bool_AnyhowException(
 
     async fn body(dart_opaque: flutter_rust_bridge::DartOpaque, arg0: Vec<u8>) -> bool {
         let args = vec![arg0.into_into_dart().into_dart()];
-        let message = FLUTTER_RUST_BRIDGE_HANDLER
-            .dart_fn_invoke(dart_opaque, args)
-            .await;
+        let message = FLUTTER_RUST_BRIDGE_HANDLER.dart_fn_invoke(dart_opaque, args).await;
 
         let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
         let action = deserializer.cursor.read_u8().unwrap();
         let ans = match action {
             0 => std::result::Result::Ok(<bool>::sse_decode(&mut deserializer)),
-            1 => std::result::Result::Err(
-                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
-            ),
+            1 => {
+                std::result::Result::Err(
+                    <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(
+                        &mut deserializer,
+                    ),
+                )
+            }
             _ => unreachable!(),
         };
         deserializer.end();
@@ -1898,17 +1866,19 @@ fn decode_DartFn_Inputs_out_point_Output_bool_AnyhowException(
         arg0: crate::utils::types::OutPoint,
     ) -> bool {
         let args = vec![arg0.into_into_dart().into_dart()];
-        let message = FLUTTER_RUST_BRIDGE_HANDLER
-            .dart_fn_invoke(dart_opaque, args)
-            .await;
+        let message = FLUTTER_RUST_BRIDGE_HANDLER.dart_fn_invoke(dart_opaque, args).await;
 
         let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
         let action = deserializer.cursor.read_u8().unwrap();
         let ans = match action {
             0 => std::result::Result::Ok(<bool>::sse_decode(&mut deserializer)),
-            1 => std::result::Result::Err(
-                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
-            ),
+            1 => {
+                std::result::Result::Err(
+                    <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(
+                        &mut deserializer,
+                    ),
+                )
+            }
             _ => unreachable!(),
         };
         deserializer.end();
@@ -2348,9 +2318,7 @@ impl SseDecode for crate::api::uri::FfiPjUriBuilder {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_internal =
             <RustOpaqueNom<payjoin_ffi::uri::PjUriBuilder>>::sse_decode(deserializer);
-        return crate::api::uri::FfiPjUriBuilder {
-            internal: var_internal,
-        };
+        return crate::api::uri::FfiPjUriBuilder { internal: var_internal };
     }
 }
 
@@ -2557,9 +2525,7 @@ impl SseDecode for Vec<(u64, crate::utils::types::OutPoint)> {
         let mut len_ = <i32>::sse_decode(deserializer);
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
-            ans_.push(<(u64, crate::utils::types::OutPoint)>::sse_decode(
-                deserializer,
-            ));
+            ans_.push(<(u64, crate::utils::types::OutPoint)>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -2616,9 +2582,7 @@ impl SseDecode for Option<crate::api::receive::FfiV2UncheckedProposal> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
-            return Some(<crate::api::receive::FfiV2UncheckedProposal>::sse_decode(
-                deserializer,
-            ));
+            return Some(<crate::api::receive::FfiV2UncheckedProposal>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -2652,10 +2616,7 @@ impl SseDecode for crate::utils::types::OutPoint {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txid = <String>::sse_decode(deserializer);
         let mut var_vout = <u32>::sse_decode(deserializer);
-        return crate::utils::types::OutPoint {
-            txid: var_txid,
-            vout: var_vout,
-        };
+        return crate::utils::types::OutPoint { txid: var_txid, vout: var_vout };
     }
 }
 
@@ -2666,15 +2627,11 @@ impl SseDecode for crate::utils::error::PayjoinError {
         match tag_ {
             0 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::InvalidAddress {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::InvalidAddress { message: var_message };
             }
             1 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::InvalidScript {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::InvalidScript { message: var_message };
             }
             2 => {
                 let mut var_message = <String>::sse_decode(deserializer);
@@ -2684,21 +2641,15 @@ impl SseDecode for crate::utils::error::PayjoinError {
             }
             3 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::PsbtParseError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::PsbtParseError { message: var_message };
             }
             4 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::ResponseError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::ResponseError { message: var_message };
             }
             5 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::RequestError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::RequestError { message: var_message };
             }
             6 => {
                 let mut var_message = <String>::sse_decode(deserializer);
@@ -2708,15 +2659,11 @@ impl SseDecode for crate::utils::error::PayjoinError {
             }
             7 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::ServerError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::ServerError { message: var_message };
             }
             8 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::SelectionError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::SelectionError { message: var_message };
             }
             9 => {
                 let mut var_message = <String>::sse_decode(deserializer);
@@ -2726,51 +2673,35 @@ impl SseDecode for crate::utils::error::PayjoinError {
             }
             10 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::PjParseError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::PjParseError { message: var_message };
             }
             11 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::PjNotSupported {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::PjNotSupported { message: var_message };
             }
             12 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::ValidationError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::ValidationError { message: var_message };
             }
             13 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::V2Error {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::V2Error { message: var_message };
             }
             14 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::UnexpectedError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::UnexpectedError { message: var_message };
             }
             15 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::OhttpError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::OhttpError { message: var_message };
             }
             16 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::UrlError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::UrlError { message: var_message };
             }
             17 => {
                 let mut var_message = <String>::sse_decode(deserializer);
-                return crate::utils::error::PayjoinError::IoError {
-                    message: var_message,
-                };
+                return crate::utils::error::PayjoinError::IoError { message: var_message };
             }
             _ => {
                 unimplemented!("");
@@ -2779,12 +2710,7 @@ impl SseDecode for crate::utils::error::PayjoinError {
     }
 }
 
-impl SseDecode
-    for (
-        crate::utils::types::Request,
-        crate::utils::types::ClientResponse,
-    )
-{
+impl SseDecode for (crate::utils::types::Request, crate::utils::types::ClientResponse) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 = <crate::utils::types::Request>::sse_decode(deserializer);
@@ -2834,10 +2760,7 @@ impl SseDecode for crate::utils::types::Request {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_url = <crate::api::uri::FfiUrl>::sse_decode(deserializer);
         let mut var_body = <Vec<u8>>::sse_decode(deserializer);
-        return crate::utils::types::Request {
-            url: var_url,
-            body: var_body,
-        };
+        return crate::utils::types::Request { url: var_url, body: var_body };
     }
 }
 
@@ -2846,10 +2769,7 @@ impl SseDecode for crate::utils::types::TxOut {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_value = <u64>::sse_decode(deserializer);
         let mut var_scriptPubkey = <Vec<u8>>::sse_decode(deserializer);
-        return crate::utils::types::TxOut {
-            value: var_value,
-            script_pubkey: var_scriptPubkey,
-        };
+        return crate::utils::types::TxOut { value: var_value, script_pubkey: var_scriptPubkey };
     }
 }
 
@@ -3377,11 +3297,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::utils::types::Network>>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::utils::types::OutPoint {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.txid.into_into_dart().into_dart(),
-            self.vout.into_into_dart().into_dart(),
-        ]
-        .into_dart()
+        [self.txid.into_into_dart().into_dart(), self.vout.into_into_dart().into_dart()].into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::utils::types::OutPoint {}
@@ -3470,11 +3386,7 @@ impl flutter_rust_bridge::IntoIntoDart<crate::utils::error::PayjoinError>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::utils::types::Request {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.url.into_into_dart().into_dart(),
-            self.body.into_into_dart().into_dart(),
-        ]
-        .into_dart()
+        [self.url.into_into_dart().into_dart(), self.body.into_into_dart().into_dart()].into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::utils::types::Request {}
@@ -3488,11 +3400,8 @@ impl flutter_rust_bridge::IntoIntoDart<crate::utils::types::Request>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::utils::types::TxOut {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.value.into_into_dart().into_dart(),
-            self.script_pubkey.into_into_dart().into_dart(),
-        ]
-        .into_dart()
+        [self.value.into_into_dart().into_dart(), self.script_pubkey.into_into_dart().into_dart()]
+            .into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::utils::types::TxOut {}
@@ -4225,12 +4134,7 @@ impl SseEncode for crate::utils::error::PayjoinError {
     }
 }
 
-impl SseEncode
-    for (
-        crate::utils::types::Request,
-        crate::utils::types::ClientResponse,
-    )
-{
+impl SseEncode for (crate::utils::types::Request, crate::utils::types::ClientResponse) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <crate::utils::types::Request>::sse_encode(self.0, serializer);
@@ -4315,10 +4219,7 @@ impl SseEncode for () {
 impl SseEncode for usize {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        serializer
-            .cursor
-            .write_u64::<NativeEndian>(self as _)
-            .unwrap();
+        serializer.cursor.write_u64::<NativeEndian>(self as _).unwrap();
     }
 }
 

--- a/rust/src/utils/types.rs
+++ b/rust/src/utils/types.rs
@@ -1,8 +1,10 @@
-use flutter_rust_bridge::frb;
-pub use payjoin_ffi::types::Network;
 use std::collections::HashMap;
 
-use crate::{api::uri::FfiUrl, frb_generated::RustOpaque};
+use flutter_rust_bridge::frb;
+pub use payjoin_ffi::types::Network;
+
+use crate::api::uri::FfiUrl;
+use crate::frb_generated::RustOpaque;
 // ///Represents data that needs to be transmitted to the receiver.
 // ///You need to send this request over HTTP(S) to the receiver.
 // #[derive(Clone, Debug)]
@@ -66,18 +68,12 @@ pub struct OutPoint {
 
 impl From<OutPoint> for payjoin_ffi::types::OutPoint {
     fn from(value: OutPoint) -> Self {
-        payjoin_ffi::types::OutPoint {
-            txid: value.txid,
-            vout: value.vout,
-        }
+        payjoin_ffi::types::OutPoint { txid: value.txid, vout: value.vout }
     }
 }
 impl From<&payjoin_ffi::types::OutPoint> for OutPoint {
     fn from(value: &payjoin_ffi::types::OutPoint) -> Self {
-        OutPoint {
-            txid: value.txid.clone(),
-            vout: value.vout,
-        }
+        OutPoint { txid: value.txid.clone(), vout: value.vout }
     }
 }
 
@@ -91,19 +87,13 @@ pub struct TxOut {
 
 impl From<TxOut> for payjoin_ffi::types::TxOut {
     fn from(tx_out: TxOut) -> Self {
-        payjoin_ffi::types::TxOut {
-            value: tx_out.value,
-            script_pubkey: tx_out.script_pubkey,
-        }
+        payjoin_ffi::types::TxOut { value: tx_out.value, script_pubkey: tx_out.script_pubkey }
     }
 }
 
 impl From<payjoin_ffi::types::TxOut> for TxOut {
     fn from(tx_out: payjoin_ffi::types::TxOut) -> Self {
-        TxOut {
-            value: tx_out.value,
-            script_pubkey: tx_out.script_pubkey,
-        }
+        TxOut { value: tx_out.value, script_pubkey: tx_out.script_pubkey }
     }
 }
 
@@ -147,9 +137,6 @@ pub struct Request {
 
 impl From<payjoin_ffi::types::Request> for Request {
     fn from(value: payjoin_ffi::types::Request) -> Self {
-        Self {
-            url: (*value.url).clone().into(),
-            body: value.body,
-        }
+        Self { url: (*value.url).clone().into(), body: value.body }
     }
 }


### PR DESCRIPTION
## [0.20.0]
#### APIs added
- Make backwards-compatible `v2` to `v1` sends possible.
#### APIs changed
- Removed `contributeNonWitnessInput`  from `v1` & `v2`.
- Allow receivers to make `payjoins` out of sweep transactions ([#259](https://github.com/payjoin/rust-payjoin/pull/259)).
- Encode &ohttp= and &exp= parameters in the &pj= URL as a fragment instead of as URI params ([#298](https://github.com/payjoin/rust-payjoin/pull/298))
