### PR TITLE
Fix core test with `bitcoin:` URI prefix

### DIFF
--- a/example/lib/payjoin_library.dart
+++ b/example/lib/payjoin_library.dart
@@ -13,7 +13,7 @@ class PayJoinLibrary {
   static const localCertFile = "localhost.der";
   Future<String> buildPjUri(double amount, String address, {String? pj}) async {
     try {
-      final pjUri = "$address?amount=$amount&pj=${pj ?? pjUrl}";
+      final pjUri = "bitcoin:$address?amount=$amount&pj=${pj ?? pjUrl}";
       await pj_uri.Uri.fromStr(pjUri);
       return pjUri;
     } catch (e) {


### PR DESCRIPTION
The test was failing for me because the bitcoin: prefix was missing from the bitcoin URIs it produced