### PR TITLE
Expose de/serialize functions for persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.21.0]
+This release updates the bindings libraries to `payjoin` version `0.21.0`.
+
+#### APIs changed
+- Major overhaul to attempt a stable BIP 77 protocol implementation.
+- v1 support is now only available through the V2 backwards-compatible APIs.
+- see [payjoin-0.21.0 changelog](https://github.com/payjoin/rust-payjoin/blob/master/payjoin/CHANGELOG.md#0210) for more details.
+
 ## [0.20.0]
 #### APIs added
 - Make backwards-compatible `v2` to `v1` sends possible.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -356,7 +356,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.20.0"
+    version: "0.21.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -239,6 +239,10 @@ typedef struct wire_cst_PayjoinError_InputPairError {
   struct wire_cst_list_prim_u_8_strict *message;
 } wire_cst_PayjoinError_InputPairError;
 
+typedef struct wire_cst_PayjoinError_SerdeJsonError {
+  struct wire_cst_list_prim_u_8_strict *message;
+} wire_cst_PayjoinError_SerdeJsonError;
+
 typedef union PayjoinErrorKind {
   struct wire_cst_PayjoinError_InvalidAddress InvalidAddress;
   struct wire_cst_PayjoinError_InvalidScript InvalidScript;
@@ -261,6 +265,7 @@ typedef union PayjoinErrorKind {
   struct wire_cst_PayjoinError_OutputSubstitutionError OutputSubstitutionError;
   struct wire_cst_PayjoinError_InputContributionError InputContributionError;
   struct wire_cst_PayjoinError_InputPairError InputPairError;
+  struct wire_cst_PayjoinError_SerdeJsonError SerdeJsonError;
 } PayjoinErrorKind;
 
 typedef struct wire_cst_payjoin_error {
@@ -352,6 +357,8 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_create(int64
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_extract_req(int64_t port_,
                                                                                 struct wire_cst_ffi_receiver *that);
 
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_from_json(struct wire_cst_list_prim_u_8_strict *json);
+
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_id(struct wire_cst_ffi_receiver *that);
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_pj_uri_builder(struct wire_cst_ffi_receiver *that);
@@ -363,6 +370,8 @@ void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_process_res(
                                                                                 struct wire_cst_ffi_receiver *that,
                                                                                 struct wire_cst_list_prim_u_8_loose *body,
                                                                                 struct wire_cst_client_response *ctx);
+
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_to_json(struct wire_cst_ffi_receiver *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(int64_t port_,
                                                                                                           struct wire_cst_ffi_unchecked_proposal *that);
@@ -430,6 +439,10 @@ void frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_extract_v1(int64_
 void frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_extract_v2(int64_t port_,
                                                                           struct wire_cst_ffi_sender *that,
                                                                           struct wire_cst_ffi_url *ohttp_proxy_url);
+
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_from_json(struct wire_cst_list_prim_u_8_strict *json);
+
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_to_json(struct wire_cst_ffi_sender *that);
 
 void frbgen_payjoin_flutter_wire__crate__api__send__ffi_v_1_context_process_response(int64_t port_,
                                                                                      struct wire_cst_ffi_v_1_context *that,
@@ -732,10 +745,12 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_provisional_proposal_finalize_proposal);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_create);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_extract_req);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_from_json);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_id);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_pj_uri_builder);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_pj_url);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_process_res);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_to_json);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_check_broadcast_suitability);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__receive__ffi_unchecked_proposal_extract_tx_to_schedule_broadcast);
@@ -753,6 +768,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_builder_from_psbt_and_uri);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_extract_v1);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_extract_v2);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_from_json);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_to_json);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_v_1_context_process_response);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_v_2_get_context_extract_req);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__send__ffi_v_2_get_context_process_response);

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -484,6 +484,8 @@ WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_bu
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_builder_pjos(struct wire_cst_ffi_pj_uri_builder *that,
                                                                                            bool pjos);
 
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_pj_endpoint(struct wire_cst_ffi_pj_uri *that);
+
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_address(struct wire_cst_ffi_uri *that);
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_amount_sats(struct wire_cst_ffi_uri *that);
@@ -783,6 +785,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_builder_label);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_builder_message);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_builder_pjos);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_pj_endpoint);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_address);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_amount_sats);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_as_string);

--- a/lib/receive.dart
+++ b/lib/receive.dart
@@ -73,6 +73,19 @@ class Receiver {
     final res = _ffiReceiver.pjUriBuilder();
     return PjUriBuilder(internal: res.internal);
   }
+
+  String toJson() {
+    return _ffiReceiver.toJson();
+  }
+
+  static Receiver fromJson(String json) {
+    try {
+      final res = FfiReceiver.fromJson(json: json);
+      return Receiver._(ffiReceiver: res);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
 }
 
 class UncheckedProposal {

--- a/lib/receive.dart
+++ b/lib/receive.dart
@@ -62,6 +62,10 @@ class Receiver {
     }
   }
 
+  String id() {
+    return _ffiReceiver.id();
+  }
+
   /// The contents of the `&pj=` query parameter including the base64url-encoded public key receiver subdirectory.
   /// This identifies a session at the payjoin directory server.
   Future<Url> pjUrl() async {

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -107,6 +107,17 @@ class Sender extends FfiSender {
       throw mapPayjoinError(e);
     }
   }
+
+  // toJson automatically exposed since class extends FfiSender
+
+  static Sender fromJson(String json) {
+    try {
+      final res = FfiSender.fromJson(json: json);
+      return Sender._(field0: res.field0);
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
 }
 
 class V1Context extends FfiV1Context {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -49,5 +49,6 @@ PayjoinException mapPayjoinError(error.PayjoinError e) {
     outputSubstitutionError: (e) => PayjoinException(message: e.message),
     inputContributionError: (e) => PayjoinException(message: e.message),
     inputPairError: (e) => PayjoinException(message: e.message),
+    serdeJsonError: (e) => PayjoinException(message: e.message),
   );
 }

--- a/lib/src/generated/api/receive.dart
+++ b/lib/src/generated/api/receive.dart
@@ -231,6 +231,9 @@ class FfiReceiver {
         that: this,
       );
 
+  static FfiReceiver fromJson({required String json}) =>
+      core.instance.api.crateApiReceiveFfiReceiverFromJson(json: json);
+
   ///The per-session public key to use as an identifier
   String id() => core.instance.api.crateApiReceiveFfiReceiverId(
         that: this,
@@ -249,6 +252,10 @@ class FfiReceiver {
           {required List<int> body, required ClientResponse ctx}) =>
       core.instance.api.crateApiReceiveFfiReceiverProcessRes(
           that: this, body: body, ctx: ctx);
+
+  String toJson() => core.instance.api.crateApiReceiveFfiReceiverToJson(
+        that: this,
+      );
 
   @override
   int get hashCode => field0.hashCode;

--- a/lib/src/generated/api/send.dart
+++ b/lib/src/generated/api/send.dart
@@ -29,6 +29,13 @@ class FfiSender {
       core.instance.api.crateApiSendFfiSenderExtractV2(
           that: this, ohttpProxyUrl: ohttpProxyUrl);
 
+  static FfiSender fromJson({required String json}) =>
+      core.instance.api.crateApiSendFfiSenderFromJson(json: json);
+
+  String toJson() => core.instance.api.crateApiSendFfiSenderToJson(
+        that: this,
+      );
+
   @override
   int get hashCode => field0.hashCode;
 

--- a/lib/src/generated/api/uri.dart
+++ b/lib/src/generated/api/uri.dart
@@ -51,6 +51,10 @@ class FfiPjUri {
         that: this,
       );
 
+  String pjEndpoint() => core.instance.api.crateApiUriFfiPjUriPjEndpoint(
+        that: this,
+      );
+
   @override
   int get hashCode => field0.hashCode;
 

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -62,7 +62,7 @@ class core extends BaseEntrypoint<coreApi, coreApiImpl, coreWire> {
   String get codegenVersion => '2.0.0';
 
   @override
-  int get rustContentHash => 1834856689;
+  int get rustContentHash => 1181881048;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -139,6 +139,8 @@ abstract class coreApi extends BaseApi {
   Future<(Request, ClientResponse)> crateApiReceiveFfiReceiverExtractReq(
       {required FfiReceiver that});
 
+  FfiReceiver crateApiReceiveFfiReceiverFromJson({required String json});
+
   String crateApiReceiveFfiReceiverId({required FfiReceiver that});
 
   FfiPjUriBuilder crateApiReceiveFfiReceiverPjUriBuilder(
@@ -150,6 +152,8 @@ abstract class coreApi extends BaseApi {
       {required FfiReceiver that,
       required List<int> body,
       required ClientResponse ctx});
+
+  String crateApiReceiveFfiReceiverToJson({required FfiReceiver that});
 
   Future<FfiMaybeInputsOwned>
       crateApiReceiveFfiUncheckedProposalAssumeInteractiveReceiver(
@@ -216,6 +220,10 @@ abstract class coreApi extends BaseApi {
 
   Future<(Request, FfiV2PostContext)> crateApiSendFfiSenderExtractV2(
       {required FfiSender that, required FfiUrl ohttpProxyUrl});
+
+  FfiSender crateApiSendFfiSenderFromJson({required String json});
+
+  String crateApiSendFfiSenderToJson({required FfiSender that});
 
   Future<String> crateApiSendFfiV1ContextProcessResponse(
       {required FfiV1Context that, required List<int> response});
@@ -931,6 +939,29 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
+  FfiReceiver crateApiReceiveFfiReceiverFromJson({required String json}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_String(json);
+        return wire.wire__crate__api__receive__ffi_receiver_from_json(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_ffi_receiver,
+        decodeErrorData: dco_decode_payjoin_error,
+      ),
+      constMeta: kCrateApiReceiveFfiReceiverFromJsonConstMeta,
+      argValues: [json],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiReceiveFfiReceiverFromJsonConstMeta =>
+      const TaskConstMeta(
+        debugName: "ffi_receiver_from_json",
+        argNames: ["json"],
+      );
+
+  @override
   String crateApiReceiveFfiReceiverId({required FfiReceiver that}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -1028,6 +1059,29 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       const TaskConstMeta(
         debugName: "ffi_receiver_process_res",
         argNames: ["that", "body", "ctx"],
+      );
+
+  @override
+  String crateApiReceiveFfiReceiverToJson({required FfiReceiver that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_ffi_receiver(that);
+        return wire.wire__crate__api__receive__ffi_receiver_to_json(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_String,
+        decodeErrorData: dco_decode_payjoin_error,
+      ),
+      constMeta: kCrateApiReceiveFfiReceiverToJsonConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiReceiveFfiReceiverToJsonConstMeta =>
+      const TaskConstMeta(
+        debugName: "ffi_receiver_to_json",
+        argNames: ["that"],
       );
 
   @override
@@ -1527,6 +1581,52 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       const TaskConstMeta(
         debugName: "ffi_sender_extract_v2",
         argNames: ["that", "ohttpProxyUrl"],
+      );
+
+  @override
+  FfiSender crateApiSendFfiSenderFromJson({required String json}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_String(json);
+        return wire.wire__crate__api__send__ffi_sender_from_json(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_ffi_sender,
+        decodeErrorData: dco_decode_payjoin_error,
+      ),
+      constMeta: kCrateApiSendFfiSenderFromJsonConstMeta,
+      argValues: [json],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSendFfiSenderFromJsonConstMeta =>
+      const TaskConstMeta(
+        debugName: "ffi_sender_from_json",
+        argNames: ["json"],
+      );
+
+  @override
+  String crateApiSendFfiSenderToJson({required FfiSender that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_ffi_sender(that);
+        return wire.wire__crate__api__send__ffi_sender_to_json(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_String,
+        decodeErrorData: dco_decode_payjoin_error,
+      ),
+      constMeta: kCrateApiSendFfiSenderToJsonConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSendFfiSenderToJsonConstMeta =>
+      const TaskConstMeta(
+        debugName: "ffi_sender_to_json",
+        argNames: ["that"],
       );
 
   @override
@@ -3085,6 +3185,10 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         return PayjoinError_InputPairError(
           message: dco_decode_String(raw[1]),
         );
+      case 21:
+        return PayjoinError_SerdeJsonError(
+          message: dco_decode_String(raw[1]),
+        );
       default:
         throw Exception("unreachable");
     }
@@ -3989,6 +4093,9 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       case 20:
         var var_message = sse_decode_String(deserializer);
         return PayjoinError_InputPairError(message: var_message);
+      case 21:
+        var var_message = sse_decode_String(deserializer);
+        return PayjoinError_SerdeJsonError(message: var_message);
       default:
         throw UnimplementedError('');
     }
@@ -5106,6 +5213,9 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         sse_encode_String(message, serializer);
       case PayjoinError_InputPairError(message: final message):
         sse_encode_i_32(20, serializer);
+        sse_encode_String(message, serializer);
+      case PayjoinError_SerdeJsonError(message: final message):
+        sse_encode_i_32(21, serializer);
         sse_encode_String(message, serializer);
       default:
         throw UnimplementedError('');

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -62,7 +62,7 @@ class core extends BaseEntrypoint<coreApi, coreApiImpl, coreWire> {
   String get codegenVersion => '2.0.0';
 
   @override
-  int get rustContentHash => 1181881048;
+  int get rustContentHash => 685157858;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -261,6 +261,8 @@ abstract class coreApi extends BaseApi {
 
   FfiPjUriBuilder crateApiUriFfiPjUriBuilderPjos(
       {required FfiPjUriBuilder that, required bool pjos});
+
+  String crateApiUriFfiPjUriPjEndpoint({required FfiPjUri that});
 
   String crateApiUriFfiUriAddress({required FfiUri that});
 
@@ -1953,6 +1955,29 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       const TaskConstMeta(
         debugName: "ffi_pj_uri_builder_pjos",
         argNames: ["that", "pjos"],
+      );
+
+  @override
+  String crateApiUriFfiPjUriPjEndpoint({required FfiPjUri that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_ffi_pj_uri(that);
+        return wire.wire__crate__api__uri__ffi_pj_uri_pj_endpoint(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiUriFfiPjUriPjEndpointConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiUriFfiPjUriPjEndpointConstMeta =>
+      const TaskConstMeta(
+        debugName: "ffi_pj_uri_pj_endpoint",
+        argNames: ["that"],
       );
 
   @override

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -1588,6 +1588,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       wireObj.kind.InputPairError.message = pre_message;
       return;
     }
+    if (apiObj is PayjoinError_SerdeJsonError) {
+      var pre_message = cst_encode_String(apiObj.message);
+      wireObj.tag = 21;
+      wireObj.kind.SerdeJsonError.message = pre_message;
+      return;
+    }
   }
 
   @protected
@@ -2569,6 +2575,24 @@ class coreWire implements BaseWire {
       _wire__crate__api__receive__ffi_receiver_extract_reqPtr
           .asFunction<void Function(int, ffi.Pointer<wire_cst_ffi_receiver>)>();
 
+  WireSyncRust2DartDco wire__crate__api__receive__ffi_receiver_from_json(
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> json,
+  ) {
+    return _wire__crate__api__receive__ffi_receiver_from_json(
+      json,
+    );
+  }
+
+  late final _wire__crate__api__receive__ffi_receiver_from_jsonPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_from_json');
+  late final _wire__crate__api__receive__ffi_receiver_from_json =
+      _wire__crate__api__receive__ffi_receiver_from_jsonPtr.asFunction<
+          WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
+
   WireSyncRust2DartDco wire__crate__api__receive__ffi_receiver_id(
     ffi.Pointer<wire_cst_ffi_receiver> that,
   ) {
@@ -2651,6 +2675,23 @@ class coreWire implements BaseWire {
               ffi.Pointer<wire_cst_ffi_receiver>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>,
               ffi.Pointer<wire_cst_client_response>)>();
+
+  WireSyncRust2DartDco wire__crate__api__receive__ffi_receiver_to_json(
+    ffi.Pointer<wire_cst_ffi_receiver> that,
+  ) {
+    return _wire__crate__api__receive__ffi_receiver_to_json(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__receive__ffi_receiver_to_jsonPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_ffi_receiver>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_to_json');
+  late final _wire__crate__api__receive__ffi_receiver_to_json =
+      _wire__crate__api__receive__ffi_receiver_to_jsonPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_receiver>)>();
 
   void
       wire__crate__api__receive__ffi_unchecked_proposal_assume_interactive_receiver(
@@ -3074,6 +3115,40 @@ class coreWire implements BaseWire {
       _wire__crate__api__send__ffi_sender_extract_v2Ptr.asFunction<
           void Function(int, ffi.Pointer<wire_cst_ffi_sender>,
               ffi.Pointer<wire_cst_ffi_url>)>();
+
+  WireSyncRust2DartDco wire__crate__api__send__ffi_sender_from_json(
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> json,
+  ) {
+    return _wire__crate__api__send__ffi_sender_from_json(
+      json,
+    );
+  }
+
+  late final _wire__crate__api__send__ffi_sender_from_jsonPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_from_json');
+  late final _wire__crate__api__send__ffi_sender_from_json =
+      _wire__crate__api__send__ffi_sender_from_jsonPtr.asFunction<
+          WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
+
+  WireSyncRust2DartDco wire__crate__api__send__ffi_sender_to_json(
+    ffi.Pointer<wire_cst_ffi_sender> that,
+  ) {
+    return _wire__crate__api__send__ffi_sender_to_json(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__send__ffi_sender_to_jsonPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_sender>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_to_json');
+  late final _wire__crate__api__send__ffi_sender_to_json =
+      _wire__crate__api__send__ffi_sender_to_jsonPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_sender>)>();
 
   void wire__crate__api__send__ffi_v_1_context_process_response(
     int port_,
@@ -4848,6 +4923,10 @@ final class wire_cst_PayjoinError_InputPairError extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
 }
 
+final class wire_cst_PayjoinError_SerdeJsonError extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
+}
+
 final class PayjoinErrorKind extends ffi.Union {
   external wire_cst_PayjoinError_InvalidAddress InvalidAddress;
 
@@ -4891,6 +4970,8 @@ final class PayjoinErrorKind extends ffi.Union {
   external wire_cst_PayjoinError_InputContributionError InputContributionError;
 
   external wire_cst_PayjoinError_InputPairError InputPairError;
+
+  external wire_cst_PayjoinError_SerdeJsonError SerdeJsonError;
 }
 
 final class wire_cst_payjoin_error extends ffi.Struct {

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -3425,6 +3425,22 @@ class coreWire implements BaseWire {
           WireSyncRust2DartDco Function(
               ffi.Pointer<wire_cst_ffi_pj_uri_builder>, bool)>();
 
+  WireSyncRust2DartDco wire__crate__api__uri__ffi_pj_uri_pj_endpoint(
+    ffi.Pointer<wire_cst_ffi_pj_uri> that,
+  ) {
+    return _wire__crate__api__uri__ffi_pj_uri_pj_endpoint(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__uri__ffi_pj_uri_pj_endpointPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_pj_uri>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_pj_endpoint');
+  late final _wire__crate__api__uri__ffi_pj_uri_pj_endpoint =
+      _wire__crate__api__uri__ffi_pj_uri_pj_endpointPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_pj_uri>)>();
+
   WireSyncRust2DartDco wire__crate__api__uri__ffi_uri_address(
     ffi.Pointer<wire_cst_ffi_uri> that,
   ) {

--- a/lib/src/generated/utils/error.dart
+++ b/lib/src/generated/utils/error.dart
@@ -85,4 +85,7 @@ sealed class PayjoinError with _$PayjoinError implements FrbException {
   const factory PayjoinError.inputPairError({
     required String message,
   }) = PayjoinError_InputPairError;
+  const factory PayjoinError.serdeJsonError({
+    required String message,
+  }) = PayjoinError_SerdeJsonError;
 }

--- a/lib/src/generated/utils/error.freezed.dart
+++ b/lib/src/generated/utils/error.freezed.dart
@@ -40,6 +40,7 @@ mixin _$PayjoinError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -65,6 +66,7 @@ mixin _$PayjoinError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -90,6 +92,7 @@ mixin _$PayjoinError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -123,6 +126,7 @@ mixin _$PayjoinError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -151,6 +155,7 @@ mixin _$PayjoinError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -178,6 +183,7 @@ mixin _$PayjoinError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -310,6 +316,7 @@ class _$PayjoinError_InvalidAddressImpl extends PayjoinError_InvalidAddress {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return invalidAddress(message);
   }
@@ -338,6 +345,7 @@ class _$PayjoinError_InvalidAddressImpl extends PayjoinError_InvalidAddress {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return invalidAddress?.call(message);
   }
@@ -366,6 +374,7 @@ class _$PayjoinError_InvalidAddressImpl extends PayjoinError_InvalidAddress {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (invalidAddress != null) {
@@ -405,6 +414,7 @@ class _$PayjoinError_InvalidAddressImpl extends PayjoinError_InvalidAddress {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return invalidAddress(this);
   }
@@ -436,6 +446,7 @@ class _$PayjoinError_InvalidAddressImpl extends PayjoinError_InvalidAddress {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return invalidAddress?.call(this);
   }
@@ -466,6 +477,7 @@ class _$PayjoinError_InvalidAddressImpl extends PayjoinError_InvalidAddress {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (invalidAddress != null) {
@@ -578,6 +590,7 @@ class _$PayjoinError_InvalidScriptImpl extends PayjoinError_InvalidScript {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return invalidScript(message);
   }
@@ -606,6 +619,7 @@ class _$PayjoinError_InvalidScriptImpl extends PayjoinError_InvalidScript {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return invalidScript?.call(message);
   }
@@ -634,6 +648,7 @@ class _$PayjoinError_InvalidScriptImpl extends PayjoinError_InvalidScript {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (invalidScript != null) {
@@ -673,6 +688,7 @@ class _$PayjoinError_InvalidScriptImpl extends PayjoinError_InvalidScript {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return invalidScript(this);
   }
@@ -704,6 +720,7 @@ class _$PayjoinError_InvalidScriptImpl extends PayjoinError_InvalidScript {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return invalidScript?.call(this);
   }
@@ -734,6 +751,7 @@ class _$PayjoinError_InvalidScriptImpl extends PayjoinError_InvalidScript {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (invalidScript != null) {
@@ -850,6 +868,7 @@ class _$PayjoinError_NetworkValidationImpl
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return networkValidation(message);
   }
@@ -878,6 +897,7 @@ class _$PayjoinError_NetworkValidationImpl
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return networkValidation?.call(message);
   }
@@ -906,6 +926,7 @@ class _$PayjoinError_NetworkValidationImpl
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (networkValidation != null) {
@@ -945,6 +966,7 @@ class _$PayjoinError_NetworkValidationImpl
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return networkValidation(this);
   }
@@ -976,6 +998,7 @@ class _$PayjoinError_NetworkValidationImpl
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return networkValidation?.call(this);
   }
@@ -1006,6 +1029,7 @@ class _$PayjoinError_NetworkValidationImpl
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (networkValidation != null) {
@@ -1119,6 +1143,7 @@ class _$PayjoinError_PsbtParseErrorImpl extends PayjoinError_PsbtParseError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return psbtParseError(message);
   }
@@ -1147,6 +1172,7 @@ class _$PayjoinError_PsbtParseErrorImpl extends PayjoinError_PsbtParseError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return psbtParseError?.call(message);
   }
@@ -1175,6 +1201,7 @@ class _$PayjoinError_PsbtParseErrorImpl extends PayjoinError_PsbtParseError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (psbtParseError != null) {
@@ -1214,6 +1241,7 @@ class _$PayjoinError_PsbtParseErrorImpl extends PayjoinError_PsbtParseError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return psbtParseError(this);
   }
@@ -1245,6 +1273,7 @@ class _$PayjoinError_PsbtParseErrorImpl extends PayjoinError_PsbtParseError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return psbtParseError?.call(this);
   }
@@ -1275,6 +1304,7 @@ class _$PayjoinError_PsbtParseErrorImpl extends PayjoinError_PsbtParseError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (psbtParseError != null) {
@@ -1387,6 +1417,7 @@ class _$PayjoinError_ResponseErrorImpl extends PayjoinError_ResponseError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return responseError(message);
   }
@@ -1415,6 +1446,7 @@ class _$PayjoinError_ResponseErrorImpl extends PayjoinError_ResponseError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return responseError?.call(message);
   }
@@ -1443,6 +1475,7 @@ class _$PayjoinError_ResponseErrorImpl extends PayjoinError_ResponseError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (responseError != null) {
@@ -1482,6 +1515,7 @@ class _$PayjoinError_ResponseErrorImpl extends PayjoinError_ResponseError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return responseError(this);
   }
@@ -1513,6 +1547,7 @@ class _$PayjoinError_ResponseErrorImpl extends PayjoinError_ResponseError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return responseError?.call(this);
   }
@@ -1543,6 +1578,7 @@ class _$PayjoinError_ResponseErrorImpl extends PayjoinError_ResponseError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (responseError != null) {
@@ -1655,6 +1691,7 @@ class _$PayjoinError_RequestErrorImpl extends PayjoinError_RequestError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return requestError(message);
   }
@@ -1683,6 +1720,7 @@ class _$PayjoinError_RequestErrorImpl extends PayjoinError_RequestError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return requestError?.call(message);
   }
@@ -1711,6 +1749,7 @@ class _$PayjoinError_RequestErrorImpl extends PayjoinError_RequestError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (requestError != null) {
@@ -1750,6 +1789,7 @@ class _$PayjoinError_RequestErrorImpl extends PayjoinError_RequestError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return requestError(this);
   }
@@ -1781,6 +1821,7 @@ class _$PayjoinError_RequestErrorImpl extends PayjoinError_RequestError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return requestError?.call(this);
   }
@@ -1811,6 +1852,7 @@ class _$PayjoinError_RequestErrorImpl extends PayjoinError_RequestError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (requestError != null) {
@@ -1927,6 +1969,7 @@ class _$PayjoinError_TransactionErrorImpl
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return transactionError(message);
   }
@@ -1955,6 +1998,7 @@ class _$PayjoinError_TransactionErrorImpl
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return transactionError?.call(message);
   }
@@ -1983,6 +2027,7 @@ class _$PayjoinError_TransactionErrorImpl
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (transactionError != null) {
@@ -2022,6 +2067,7 @@ class _$PayjoinError_TransactionErrorImpl
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return transactionError(this);
   }
@@ -2053,6 +2099,7 @@ class _$PayjoinError_TransactionErrorImpl
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return transactionError?.call(this);
   }
@@ -2083,6 +2130,7 @@ class _$PayjoinError_TransactionErrorImpl
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (transactionError != null) {
@@ -2196,6 +2244,7 @@ class _$PayjoinError_ServerErrorImpl extends PayjoinError_ServerError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return serverError(message);
   }
@@ -2224,6 +2273,7 @@ class _$PayjoinError_ServerErrorImpl extends PayjoinError_ServerError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return serverError?.call(message);
   }
@@ -2252,6 +2302,7 @@ class _$PayjoinError_ServerErrorImpl extends PayjoinError_ServerError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (serverError != null) {
@@ -2291,6 +2342,7 @@ class _$PayjoinError_ServerErrorImpl extends PayjoinError_ServerError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return serverError(this);
   }
@@ -2322,6 +2374,7 @@ class _$PayjoinError_ServerErrorImpl extends PayjoinError_ServerError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return serverError?.call(this);
   }
@@ -2352,6 +2405,7 @@ class _$PayjoinError_ServerErrorImpl extends PayjoinError_ServerError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (serverError != null) {
@@ -2464,6 +2518,7 @@ class _$PayjoinError_SelectionErrorImpl extends PayjoinError_SelectionError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return selectionError(message);
   }
@@ -2492,6 +2547,7 @@ class _$PayjoinError_SelectionErrorImpl extends PayjoinError_SelectionError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return selectionError?.call(message);
   }
@@ -2520,6 +2576,7 @@ class _$PayjoinError_SelectionErrorImpl extends PayjoinError_SelectionError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (selectionError != null) {
@@ -2559,6 +2616,7 @@ class _$PayjoinError_SelectionErrorImpl extends PayjoinError_SelectionError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return selectionError(this);
   }
@@ -2590,6 +2648,7 @@ class _$PayjoinError_SelectionErrorImpl extends PayjoinError_SelectionError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return selectionError?.call(this);
   }
@@ -2620,6 +2679,7 @@ class _$PayjoinError_SelectionErrorImpl extends PayjoinError_SelectionError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (selectionError != null) {
@@ -2736,6 +2796,7 @@ class _$PayjoinError_CreateRequestErrorImpl
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return createRequestError(message);
   }
@@ -2764,6 +2825,7 @@ class _$PayjoinError_CreateRequestErrorImpl
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return createRequestError?.call(message);
   }
@@ -2792,6 +2854,7 @@ class _$PayjoinError_CreateRequestErrorImpl
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (createRequestError != null) {
@@ -2831,6 +2894,7 @@ class _$PayjoinError_CreateRequestErrorImpl
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return createRequestError(this);
   }
@@ -2862,6 +2926,7 @@ class _$PayjoinError_CreateRequestErrorImpl
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return createRequestError?.call(this);
   }
@@ -2892,6 +2957,7 @@ class _$PayjoinError_CreateRequestErrorImpl
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (createRequestError != null) {
@@ -3005,6 +3071,7 @@ class _$PayjoinError_PjParseErrorImpl extends PayjoinError_PjParseError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return pjParseError(message);
   }
@@ -3033,6 +3100,7 @@ class _$PayjoinError_PjParseErrorImpl extends PayjoinError_PjParseError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return pjParseError?.call(message);
   }
@@ -3061,6 +3129,7 @@ class _$PayjoinError_PjParseErrorImpl extends PayjoinError_PjParseError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (pjParseError != null) {
@@ -3100,6 +3169,7 @@ class _$PayjoinError_PjParseErrorImpl extends PayjoinError_PjParseError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return pjParseError(this);
   }
@@ -3131,6 +3201,7 @@ class _$PayjoinError_PjParseErrorImpl extends PayjoinError_PjParseError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return pjParseError?.call(this);
   }
@@ -3161,6 +3232,7 @@ class _$PayjoinError_PjParseErrorImpl extends PayjoinError_PjParseError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (pjParseError != null) {
@@ -3273,6 +3345,7 @@ class _$PayjoinError_PjNotSupportedImpl extends PayjoinError_PjNotSupported {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return pjNotSupported(message);
   }
@@ -3301,6 +3374,7 @@ class _$PayjoinError_PjNotSupportedImpl extends PayjoinError_PjNotSupported {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return pjNotSupported?.call(message);
   }
@@ -3329,6 +3403,7 @@ class _$PayjoinError_PjNotSupportedImpl extends PayjoinError_PjNotSupported {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (pjNotSupported != null) {
@@ -3368,6 +3443,7 @@ class _$PayjoinError_PjNotSupportedImpl extends PayjoinError_PjNotSupported {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return pjNotSupported(this);
   }
@@ -3399,6 +3475,7 @@ class _$PayjoinError_PjNotSupportedImpl extends PayjoinError_PjNotSupported {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return pjNotSupported?.call(this);
   }
@@ -3429,6 +3506,7 @@ class _$PayjoinError_PjNotSupportedImpl extends PayjoinError_PjNotSupported {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (pjNotSupported != null) {
@@ -3542,6 +3620,7 @@ class _$PayjoinError_ValidationErrorImpl extends PayjoinError_ValidationError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return validationError(message);
   }
@@ -3570,6 +3649,7 @@ class _$PayjoinError_ValidationErrorImpl extends PayjoinError_ValidationError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return validationError?.call(message);
   }
@@ -3598,6 +3678,7 @@ class _$PayjoinError_ValidationErrorImpl extends PayjoinError_ValidationError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (validationError != null) {
@@ -3637,6 +3718,7 @@ class _$PayjoinError_ValidationErrorImpl extends PayjoinError_ValidationError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return validationError(this);
   }
@@ -3668,6 +3750,7 @@ class _$PayjoinError_ValidationErrorImpl extends PayjoinError_ValidationError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return validationError?.call(this);
   }
@@ -3698,6 +3781,7 @@ class _$PayjoinError_ValidationErrorImpl extends PayjoinError_ValidationError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (validationError != null) {
@@ -3810,6 +3894,7 @@ class _$PayjoinError_V2ErrorImpl extends PayjoinError_V2Error {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return v2Error(message);
   }
@@ -3838,6 +3923,7 @@ class _$PayjoinError_V2ErrorImpl extends PayjoinError_V2Error {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return v2Error?.call(message);
   }
@@ -3866,6 +3952,7 @@ class _$PayjoinError_V2ErrorImpl extends PayjoinError_V2Error {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (v2Error != null) {
@@ -3905,6 +3992,7 @@ class _$PayjoinError_V2ErrorImpl extends PayjoinError_V2Error {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return v2Error(this);
   }
@@ -3936,6 +4024,7 @@ class _$PayjoinError_V2ErrorImpl extends PayjoinError_V2Error {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return v2Error?.call(this);
   }
@@ -3966,6 +4055,7 @@ class _$PayjoinError_V2ErrorImpl extends PayjoinError_V2Error {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (v2Error != null) {
@@ -4079,6 +4169,7 @@ class _$PayjoinError_UnexpectedErrorImpl extends PayjoinError_UnexpectedError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return unexpectedError(message);
   }
@@ -4107,6 +4198,7 @@ class _$PayjoinError_UnexpectedErrorImpl extends PayjoinError_UnexpectedError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return unexpectedError?.call(message);
   }
@@ -4135,6 +4227,7 @@ class _$PayjoinError_UnexpectedErrorImpl extends PayjoinError_UnexpectedError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (unexpectedError != null) {
@@ -4174,6 +4267,7 @@ class _$PayjoinError_UnexpectedErrorImpl extends PayjoinError_UnexpectedError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return unexpectedError(this);
   }
@@ -4205,6 +4299,7 @@ class _$PayjoinError_UnexpectedErrorImpl extends PayjoinError_UnexpectedError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return unexpectedError?.call(this);
   }
@@ -4235,6 +4330,7 @@ class _$PayjoinError_UnexpectedErrorImpl extends PayjoinError_UnexpectedError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (unexpectedError != null) {
@@ -4348,6 +4444,7 @@ class _$PayjoinError_OhttpErrorImpl extends PayjoinError_OhttpError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return ohttpError(message);
   }
@@ -4376,6 +4473,7 @@ class _$PayjoinError_OhttpErrorImpl extends PayjoinError_OhttpError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return ohttpError?.call(message);
   }
@@ -4404,6 +4502,7 @@ class _$PayjoinError_OhttpErrorImpl extends PayjoinError_OhttpError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (ohttpError != null) {
@@ -4443,6 +4542,7 @@ class _$PayjoinError_OhttpErrorImpl extends PayjoinError_OhttpError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return ohttpError(this);
   }
@@ -4474,6 +4574,7 @@ class _$PayjoinError_OhttpErrorImpl extends PayjoinError_OhttpError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return ohttpError?.call(this);
   }
@@ -4504,6 +4605,7 @@ class _$PayjoinError_OhttpErrorImpl extends PayjoinError_OhttpError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (ohttpError != null) {
@@ -4615,6 +4717,7 @@ class _$PayjoinError_UrlErrorImpl extends PayjoinError_UrlError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return urlError(message);
   }
@@ -4643,6 +4746,7 @@ class _$PayjoinError_UrlErrorImpl extends PayjoinError_UrlError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return urlError?.call(message);
   }
@@ -4671,6 +4775,7 @@ class _$PayjoinError_UrlErrorImpl extends PayjoinError_UrlError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (urlError != null) {
@@ -4710,6 +4815,7 @@ class _$PayjoinError_UrlErrorImpl extends PayjoinError_UrlError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return urlError(this);
   }
@@ -4741,6 +4847,7 @@ class _$PayjoinError_UrlErrorImpl extends PayjoinError_UrlError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return urlError?.call(this);
   }
@@ -4771,6 +4878,7 @@ class _$PayjoinError_UrlErrorImpl extends PayjoinError_UrlError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (urlError != null) {
@@ -4882,6 +4990,7 @@ class _$PayjoinError_IoErrorImpl extends PayjoinError_IoError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return ioError(message);
   }
@@ -4910,6 +5019,7 @@ class _$PayjoinError_IoErrorImpl extends PayjoinError_IoError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return ioError?.call(message);
   }
@@ -4938,6 +5048,7 @@ class _$PayjoinError_IoErrorImpl extends PayjoinError_IoError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (ioError != null) {
@@ -4977,6 +5088,7 @@ class _$PayjoinError_IoErrorImpl extends PayjoinError_IoError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return ioError(this);
   }
@@ -5008,6 +5120,7 @@ class _$PayjoinError_IoErrorImpl extends PayjoinError_IoError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return ioError?.call(this);
   }
@@ -5038,6 +5151,7 @@ class _$PayjoinError_IoErrorImpl extends PayjoinError_IoError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (ioError != null) {
@@ -5154,6 +5268,7 @@ class _$PayjoinError_OutputSubstitutionErrorImpl
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return outputSubstitutionError(message);
   }
@@ -5182,6 +5297,7 @@ class _$PayjoinError_OutputSubstitutionErrorImpl
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return outputSubstitutionError?.call(message);
   }
@@ -5210,6 +5326,7 @@ class _$PayjoinError_OutputSubstitutionErrorImpl
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (outputSubstitutionError != null) {
@@ -5249,6 +5366,7 @@ class _$PayjoinError_OutputSubstitutionErrorImpl
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return outputSubstitutionError(this);
   }
@@ -5280,6 +5398,7 @@ class _$PayjoinError_OutputSubstitutionErrorImpl
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return outputSubstitutionError?.call(this);
   }
@@ -5310,6 +5429,7 @@ class _$PayjoinError_OutputSubstitutionErrorImpl
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (outputSubstitutionError != null) {
@@ -5428,6 +5548,7 @@ class _$PayjoinError_InputContributionErrorImpl
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return inputContributionError(message);
   }
@@ -5456,6 +5577,7 @@ class _$PayjoinError_InputContributionErrorImpl
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return inputContributionError?.call(message);
   }
@@ -5484,6 +5606,7 @@ class _$PayjoinError_InputContributionErrorImpl
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (inputContributionError != null) {
@@ -5523,6 +5646,7 @@ class _$PayjoinError_InputContributionErrorImpl
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return inputContributionError(this);
   }
@@ -5554,6 +5678,7 @@ class _$PayjoinError_InputContributionErrorImpl
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return inputContributionError?.call(this);
   }
@@ -5584,6 +5709,7 @@ class _$PayjoinError_InputContributionErrorImpl
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (inputContributionError != null) {
@@ -5698,6 +5824,7 @@ class _$PayjoinError_InputPairErrorImpl extends PayjoinError_InputPairError {
     required TResult Function(String message) outputSubstitutionError,
     required TResult Function(String message) inputContributionError,
     required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
   }) {
     return inputPairError(message);
   }
@@ -5726,6 +5853,7 @@ class _$PayjoinError_InputPairErrorImpl extends PayjoinError_InputPairError {
     TResult? Function(String message)? outputSubstitutionError,
     TResult? Function(String message)? inputContributionError,
     TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
   }) {
     return inputPairError?.call(message);
   }
@@ -5754,6 +5882,7 @@ class _$PayjoinError_InputPairErrorImpl extends PayjoinError_InputPairError {
     TResult Function(String message)? outputSubstitutionError,
     TResult Function(String message)? inputContributionError,
     TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (inputPairError != null) {
@@ -5793,6 +5922,7 @@ class _$PayjoinError_InputPairErrorImpl extends PayjoinError_InputPairError {
     required TResult Function(PayjoinError_InputContributionError value)
         inputContributionError,
     required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
   }) {
     return inputPairError(this);
   }
@@ -5824,6 +5954,7 @@ class _$PayjoinError_InputPairErrorImpl extends PayjoinError_InputPairError {
     TResult? Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
   }) {
     return inputPairError?.call(this);
   }
@@ -5854,6 +5985,7 @@ class _$PayjoinError_InputPairErrorImpl extends PayjoinError_InputPairError {
     TResult Function(PayjoinError_InputContributionError value)?
         inputContributionError,
     TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
     required TResult orElse(),
   }) {
     if (inputPairError != null) {
@@ -5873,5 +6005,279 @@ abstract class PayjoinError_InputPairError extends PayjoinError {
   @override
   @JsonKey(ignore: true)
   _$$PayjoinError_InputPairErrorImplCopyWith<_$PayjoinError_InputPairErrorImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PayjoinError_SerdeJsonErrorImplCopyWith<$Res>
+    implements $PayjoinErrorCopyWith<$Res> {
+  factory _$$PayjoinError_SerdeJsonErrorImplCopyWith(
+          _$PayjoinError_SerdeJsonErrorImpl value,
+          $Res Function(_$PayjoinError_SerdeJsonErrorImpl) then) =
+      __$$PayjoinError_SerdeJsonErrorImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$PayjoinError_SerdeJsonErrorImplCopyWithImpl<$Res>
+    extends _$PayjoinErrorCopyWithImpl<$Res, _$PayjoinError_SerdeJsonErrorImpl>
+    implements _$$PayjoinError_SerdeJsonErrorImplCopyWith<$Res> {
+  __$$PayjoinError_SerdeJsonErrorImplCopyWithImpl(
+      _$PayjoinError_SerdeJsonErrorImpl _value,
+      $Res Function(_$PayjoinError_SerdeJsonErrorImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$PayjoinError_SerdeJsonErrorImpl(
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PayjoinError_SerdeJsonErrorImpl extends PayjoinError_SerdeJsonError {
+  const _$PayjoinError_SerdeJsonErrorImpl({required this.message}) : super._();
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'PayjoinError.serdeJsonError(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PayjoinError_SerdeJsonErrorImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PayjoinError_SerdeJsonErrorImplCopyWith<_$PayjoinError_SerdeJsonErrorImpl>
+      get copyWith => __$$PayjoinError_SerdeJsonErrorImplCopyWithImpl<
+          _$PayjoinError_SerdeJsonErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) invalidAddress,
+    required TResult Function(String message) invalidScript,
+    required TResult Function(String message) networkValidation,
+    required TResult Function(String message) psbtParseError,
+    required TResult Function(String message) responseError,
+    required TResult Function(String message) requestError,
+    required TResult Function(String message) transactionError,
+    required TResult Function(String message) serverError,
+    required TResult Function(String message) selectionError,
+    required TResult Function(String message) createRequestError,
+    required TResult Function(String message) pjParseError,
+    required TResult Function(String message) pjNotSupported,
+    required TResult Function(String message) validationError,
+    required TResult Function(String message) v2Error,
+    required TResult Function(String message) unexpectedError,
+    required TResult Function(String message) ohttpError,
+    required TResult Function(String message) urlError,
+    required TResult Function(String message) ioError,
+    required TResult Function(String message) outputSubstitutionError,
+    required TResult Function(String message) inputContributionError,
+    required TResult Function(String message) inputPairError,
+    required TResult Function(String message) serdeJsonError,
+  }) {
+    return serdeJsonError(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? invalidAddress,
+    TResult? Function(String message)? invalidScript,
+    TResult? Function(String message)? networkValidation,
+    TResult? Function(String message)? psbtParseError,
+    TResult? Function(String message)? responseError,
+    TResult? Function(String message)? requestError,
+    TResult? Function(String message)? transactionError,
+    TResult? Function(String message)? serverError,
+    TResult? Function(String message)? selectionError,
+    TResult? Function(String message)? createRequestError,
+    TResult? Function(String message)? pjParseError,
+    TResult? Function(String message)? pjNotSupported,
+    TResult? Function(String message)? validationError,
+    TResult? Function(String message)? v2Error,
+    TResult? Function(String message)? unexpectedError,
+    TResult? Function(String message)? ohttpError,
+    TResult? Function(String message)? urlError,
+    TResult? Function(String message)? ioError,
+    TResult? Function(String message)? outputSubstitutionError,
+    TResult? Function(String message)? inputContributionError,
+    TResult? Function(String message)? inputPairError,
+    TResult? Function(String message)? serdeJsonError,
+  }) {
+    return serdeJsonError?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? invalidAddress,
+    TResult Function(String message)? invalidScript,
+    TResult Function(String message)? networkValidation,
+    TResult Function(String message)? psbtParseError,
+    TResult Function(String message)? responseError,
+    TResult Function(String message)? requestError,
+    TResult Function(String message)? transactionError,
+    TResult Function(String message)? serverError,
+    TResult Function(String message)? selectionError,
+    TResult Function(String message)? createRequestError,
+    TResult Function(String message)? pjParseError,
+    TResult Function(String message)? pjNotSupported,
+    TResult Function(String message)? validationError,
+    TResult Function(String message)? v2Error,
+    TResult Function(String message)? unexpectedError,
+    TResult Function(String message)? ohttpError,
+    TResult Function(String message)? urlError,
+    TResult Function(String message)? ioError,
+    TResult Function(String message)? outputSubstitutionError,
+    TResult Function(String message)? inputContributionError,
+    TResult Function(String message)? inputPairError,
+    TResult Function(String message)? serdeJsonError,
+    required TResult orElse(),
+  }) {
+    if (serdeJsonError != null) {
+      return serdeJsonError(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PayjoinError_InvalidAddress value) invalidAddress,
+    required TResult Function(PayjoinError_InvalidScript value) invalidScript,
+    required TResult Function(PayjoinError_NetworkValidation value)
+        networkValidation,
+    required TResult Function(PayjoinError_PsbtParseError value) psbtParseError,
+    required TResult Function(PayjoinError_ResponseError value) responseError,
+    required TResult Function(PayjoinError_RequestError value) requestError,
+    required TResult Function(PayjoinError_TransactionError value)
+        transactionError,
+    required TResult Function(PayjoinError_ServerError value) serverError,
+    required TResult Function(PayjoinError_SelectionError value) selectionError,
+    required TResult Function(PayjoinError_CreateRequestError value)
+        createRequestError,
+    required TResult Function(PayjoinError_PjParseError value) pjParseError,
+    required TResult Function(PayjoinError_PjNotSupported value) pjNotSupported,
+    required TResult Function(PayjoinError_ValidationError value)
+        validationError,
+    required TResult Function(PayjoinError_V2Error value) v2Error,
+    required TResult Function(PayjoinError_UnexpectedError value)
+        unexpectedError,
+    required TResult Function(PayjoinError_OhttpError value) ohttpError,
+    required TResult Function(PayjoinError_UrlError value) urlError,
+    required TResult Function(PayjoinError_IoError value) ioError,
+    required TResult Function(PayjoinError_OutputSubstitutionError value)
+        outputSubstitutionError,
+    required TResult Function(PayjoinError_InputContributionError value)
+        inputContributionError,
+    required TResult Function(PayjoinError_InputPairError value) inputPairError,
+    required TResult Function(PayjoinError_SerdeJsonError value) serdeJsonError,
+  }) {
+    return serdeJsonError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PayjoinError_InvalidAddress value)? invalidAddress,
+    TResult? Function(PayjoinError_InvalidScript value)? invalidScript,
+    TResult? Function(PayjoinError_NetworkValidation value)? networkValidation,
+    TResult? Function(PayjoinError_PsbtParseError value)? psbtParseError,
+    TResult? Function(PayjoinError_ResponseError value)? responseError,
+    TResult? Function(PayjoinError_RequestError value)? requestError,
+    TResult? Function(PayjoinError_TransactionError value)? transactionError,
+    TResult? Function(PayjoinError_ServerError value)? serverError,
+    TResult? Function(PayjoinError_SelectionError value)? selectionError,
+    TResult? Function(PayjoinError_CreateRequestError value)?
+        createRequestError,
+    TResult? Function(PayjoinError_PjParseError value)? pjParseError,
+    TResult? Function(PayjoinError_PjNotSupported value)? pjNotSupported,
+    TResult? Function(PayjoinError_ValidationError value)? validationError,
+    TResult? Function(PayjoinError_V2Error value)? v2Error,
+    TResult? Function(PayjoinError_UnexpectedError value)? unexpectedError,
+    TResult? Function(PayjoinError_OhttpError value)? ohttpError,
+    TResult? Function(PayjoinError_UrlError value)? urlError,
+    TResult? Function(PayjoinError_IoError value)? ioError,
+    TResult? Function(PayjoinError_OutputSubstitutionError value)?
+        outputSubstitutionError,
+    TResult? Function(PayjoinError_InputContributionError value)?
+        inputContributionError,
+    TResult? Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult? Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
+  }) {
+    return serdeJsonError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PayjoinError_InvalidAddress value)? invalidAddress,
+    TResult Function(PayjoinError_InvalidScript value)? invalidScript,
+    TResult Function(PayjoinError_NetworkValidation value)? networkValidation,
+    TResult Function(PayjoinError_PsbtParseError value)? psbtParseError,
+    TResult Function(PayjoinError_ResponseError value)? responseError,
+    TResult Function(PayjoinError_RequestError value)? requestError,
+    TResult Function(PayjoinError_TransactionError value)? transactionError,
+    TResult Function(PayjoinError_ServerError value)? serverError,
+    TResult Function(PayjoinError_SelectionError value)? selectionError,
+    TResult Function(PayjoinError_CreateRequestError value)? createRequestError,
+    TResult Function(PayjoinError_PjParseError value)? pjParseError,
+    TResult Function(PayjoinError_PjNotSupported value)? pjNotSupported,
+    TResult Function(PayjoinError_ValidationError value)? validationError,
+    TResult Function(PayjoinError_V2Error value)? v2Error,
+    TResult Function(PayjoinError_UnexpectedError value)? unexpectedError,
+    TResult Function(PayjoinError_OhttpError value)? ohttpError,
+    TResult Function(PayjoinError_UrlError value)? urlError,
+    TResult Function(PayjoinError_IoError value)? ioError,
+    TResult Function(PayjoinError_OutputSubstitutionError value)?
+        outputSubstitutionError,
+    TResult Function(PayjoinError_InputContributionError value)?
+        inputContributionError,
+    TResult Function(PayjoinError_InputPairError value)? inputPairError,
+    TResult Function(PayjoinError_SerdeJsonError value)? serdeJsonError,
+    required TResult orElse(),
+  }) {
+    if (serdeJsonError != null) {
+      return serdeJsonError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PayjoinError_SerdeJsonError extends PayjoinError {
+  const factory PayjoinError_SerdeJsonError({required final String message}) =
+      _$PayjoinError_SerdeJsonErrorImpl;
+  const PayjoinError_SerdeJsonError._() : super._();
+
+  @override
+  String get message;
+  @override
+  @JsonKey(ignore: true)
+  _$$PayjoinError_SerdeJsonErrorImplCopyWith<_$PayjoinError_SerdeJsonErrorImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/uri.dart
+++ b/lib/uri.dart
@@ -122,6 +122,15 @@ class PjUri extends FfiPjUri {
       throw mapPayjoinError(e);
     }
   }
+
+  @override
+  String pjEndpoint({hint}) {
+    try {
+      return super.pjEndpoint();
+    } on error.PayjoinError catch (e) {
+      throw mapPayjoinError(e);
+    }
+  }
 }
 
 class Url extends FfiUrl {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: payjoin_flutter
 description: "A Flutter library for the [Payjoin Dev Kit](https://payjoindevkit.org/)"
-version: 0.20.0
+version: 0.21.0
 homepage: https://github.com/LtbLightning/payjoin-flutter
 
 environment:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "shlex",
 ]
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -1542,9 +1542,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1570,9 +1570,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "litemap"
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763d142cdff44aaadd9268bebddb156ef6c65a0e13486bb81673cf2d8739f9b0"
+checksum = "36a8e50e917e18a37d500d27d40b7bc7d127e71c0c94fb2d83f43b4afd308390"
 dependencies = [
  "log",
  "serde",
@@ -1781,8 +1781,8 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.21.1"
-source = "git+https://github.com/LtbLightning/payjoin-ffi?tag=v0.21.1#b2dc4318cc01337b9c28990e797fd47534cfb8c4"
+version = "0.21.2"
+source = "git+https://github.com/LtbLightning/payjoin-ffi?tag=v0.21.2#a9d7f7c7d1902b9ea4ee4e9f3c0683abf12dbc39"
 dependencies = [
  "base64 0.22.1",
  "bitcoin-ffi",
@@ -1904,7 +1904,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.19",
  "socket2",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "tracing",
 ]
@@ -1923,7 +1923,7 @@ dependencies = [
  "rustls 0.23.19",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2492,11 +2492,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl 2.0.4",
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2584,12 +2584,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls 0.23.19",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -2889,9 +2888,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2900,13 +2899,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -2915,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2928,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2938,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2951,15 +2949,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1781,14 +1781,15 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.21.0"
-source = "git+https://github.com/LtbLightning/payjoin-ffi?tag=v0.21.0#5230f1999284659346cbd7c8bac5211061a5a3b2"
+version = "0.21.1"
+source = "git+https://github.com/LtbLightning/payjoin-ffi?tag=v0.21.1#b2dc4318cc01337b9c28990e797fd47534cfb8c4"
 dependencies = [
  "base64 0.22.1",
  "bitcoin-ffi",
  "bitcoin-ohttp",
  "hex",
  "payjoin",
+ "serde_json",
  "thiserror 1.0.69",
  "uniffi",
  "url",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin_flutter"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ bitcoincore-rpc = "0.19.0"
 anyhow = "1.0.68"
 [dependencies]
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", rev = "4cd8e644dbf4e001d71d5fffb232480fa5ff2246" }
-payjoin_ffi = { git = "https://github.com/LtbLightning/payjoin-ffi", tag = "v0.21.0" }
+payjoin_ffi = { git = "https://github.com/LtbLightning/payjoin-ffi", tag = "v0.21.1" }
 flutter_rust_bridge = "=2.0.0"
 anyhow = "1.0.68"
 tokio = "1.36.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ bitcoincore-rpc = "0.19.0"
 anyhow = "1.0.68"
 [dependencies]
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", rev = "4cd8e644dbf4e001d71d5fffb232480fa5ff2246" }
-payjoin_ffi = { git = "https://github.com/LtbLightning/payjoin-ffi", tag = "v0.21.1" }
+payjoin_ffi = { git = "https://github.com/LtbLightning/payjoin-ffi", tag = "v0.21.2" }
 flutter_rust_bridge = "=2.0.0"
 anyhow = "1.0.68"
 tokio = "1.36.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin_flutter"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 
 [lib]

--- a/rust/src/api/receive.rs
+++ b/rust/src/api/receive.rs
@@ -76,6 +76,16 @@ impl FfiReceiver {
     ) -> Result<Option<FfiUncheckedProposal>, PayjoinError> {
         self.0.process_res(body, &ctx.into()).map(|e| e.map(|o| o.into())).map_err(|e| e.into())
     }
+
+    #[frb(sync)]
+    pub fn to_json(&self) -> Result<String, PayjoinError> {
+        self.0.to_json().map_err(Into::into)
+    }
+
+    #[frb(sync)]
+    pub fn from_json(json: String) -> Result<Self, PayjoinError> {
+        payjoin_ffi::receive::Receiver::from_json(&json).map(Into::into).map_err(Into::into)
+    }
 }
 
 #[derive(Clone)]

--- a/rust/src/api/send.rs
+++ b/rust/src/api/send.rs
@@ -1,3 +1,5 @@
+use flutter_rust_bridge::frb;
+
 use super::receive::PayjoinError;
 use crate::api::uri::{FfiPjUri, FfiUrl};
 use crate::frb_generated::RustOpaque;
@@ -76,6 +78,16 @@ impl FfiSender {
             .extract_v2(ohttp_proxy_url.into())
             .map(|(req, ctx)| (req.into(), ctx.into()))
             .map_err(Into::into)
+    }
+
+    #[frb(sync)]
+    pub fn to_json(&self) -> Result<String, PayjoinError> {
+        self.0.to_json().map_err(Into::into)
+    }
+
+    #[frb(sync)]
+    pub fn from_json(json: String) -> Result<Self, PayjoinError> {
+        payjoin_ffi::send::Sender::from_json(&json).map(Into::into).map_err(Into::into)
     }
 }
 

--- a/rust/src/api/uri.rs
+++ b/rust/src/api/uri.rs
@@ -58,6 +58,12 @@ impl FfiPjUri {
     pub fn amount_sats(&self) -> Option<u64> {
         self.0.clone().amount_sats()
     }
+
+    #[frb(sync)]
+    pub fn pj_endpoint(&self) -> String {
+        self.0.clone().pj_endpoint()
+    }
+
     #[frb(sync)]
     pub fn as_string(&self) -> String {
         self.0.clone().as_string()

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -671,6 +671,12 @@ impl CstDecode<crate::utils::error::PayjoinError> for wire_cst_payjoin_error {
                     message: ans.message.cst_decode(),
                 }
             }
+            21 => {
+                let ans = unsafe { self.kind.SerdeJsonError };
+                crate::utils::error::PayjoinError::SerdeJsonError {
+                    message: ans.message.cst_decode(),
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -1236,6 +1242,13 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_from_json(
+    json: *mut wire_cst_list_prim_u_8_strict,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__receive__ffi_receiver_from_json_impl(json)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_id(
     that: *mut wire_cst_ffi_receiver,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
@@ -1265,6 +1278,13 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver
     ctx: *mut wire_cst_client_response,
 ) {
     wire__crate__api__receive__ffi_receiver_process_res_impl(port_, that, body, ctx)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__receive__ffi_receiver_to_json(
+    that: *mut wire_cst_ffi_receiver,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__receive__ffi_receiver_to_json_impl(that)
 }
 
 #[no_mangle]
@@ -1454,6 +1474,20 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_extr
     ohttp_proxy_url: *mut wire_cst_ffi_url,
 ) {
     wire__crate__api__send__ffi_sender_extract_v2_impl(port_, that, ohttp_proxy_url)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_from_json(
+    json: *mut wire_cst_list_prim_u_8_strict,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__send__ffi_sender_from_json_impl(json)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__send__ffi_sender_to_json(
+    that: *mut wire_cst_ffi_sender,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__send__ffi_sender_to_json_impl(that)
 }
 
 #[no_mangle]
@@ -2455,6 +2489,7 @@ pub union PayjoinErrorKind {
     OutputSubstitutionError: wire_cst_PayjoinError_OutputSubstitutionError,
     InputContributionError: wire_cst_PayjoinError_InputContributionError,
     InputPairError: wire_cst_PayjoinError_InputPairError,
+    SerdeJsonError: wire_cst_PayjoinError_SerdeJsonError,
     nil__: (),
 }
 #[repr(C)]
@@ -2560,6 +2595,11 @@ pub struct wire_cst_PayjoinError_InputContributionError {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct wire_cst_PayjoinError_InputPairError {
+    message: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_PayjoinError_SerdeJsonError {
     message: *mut wire_cst_list_prim_u_8_strict,
 }
 #[repr(C)]

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -1598,6 +1598,13 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_build
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_pj_uri_pj_endpoint(
+    that: *mut wire_cst_ffi_pj_uri,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__uri__ffi_pj_uri_pj_endpoint_impl(that)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_address(
     that: *mut wire_cst_ffi_uri,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1181881048;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 685157858;
 
 // Section: executor
 
@@ -1393,6 +1393,25 @@ fn wire__crate__api__uri__ffi_pj_uri_builder_pjos_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::uri::FfiPjUriBuilder::pjos(
                     &api_that, api_pjos,
                 ))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__uri__ffi_pj_uri_pj_endpoint_impl(
+    that: impl CstDecode<crate::api::uri::FfiPjUri>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_pj_uri_pj_endpoint",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::uri::FfiPjUri::pj_endpoint(&api_that))?;
                 Ok(output_ok)
             })())
         },

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1834856689;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1181881048;
 
 // Section: executor
 
@@ -485,6 +485,24 @@ fn wire__crate__api__receive__ffi_receiver_extract_req_impl(
         },
     )
 }
+fn wire__crate__api__receive__ffi_receiver_from_json_impl(
+    json: impl CstDecode<String>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_receiver_from_json",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_json = json.cst_decode();
+            transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
+                let output_ok = crate::api::receive::FfiReceiver::from_json(api_json)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__receive__ffi_receiver_id_impl(
     that: impl CstDecode<crate::api::receive::FfiReceiver>,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
@@ -571,6 +589,24 @@ fn wire__crate__api__receive__ffi_receiver_process_res_impl(
                 })(
                 ))
             }
+        },
+    )
+}
+fn wire__crate__api__receive__ffi_receiver_to_json_impl(
+    that: impl CstDecode<crate::api::receive::FfiReceiver>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_receiver_to_json",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
+                let output_ok = crate::api::receive::FfiReceiver::to_json(&api_that)?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -1030,6 +1066,42 @@ fn wire__crate__api__send__ffi_sender_extract_v2_impl(
                 })(
                 ))
             }
+        },
+    )
+}
+fn wire__crate__api__send__ffi_sender_from_json_impl(
+    json: impl CstDecode<String>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_sender_from_json",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_json = json.cst_decode();
+            transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
+                let output_ok = crate::api::send::FfiSender::from_json(api_json)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__send__ffi_sender_to_json_impl(
+    that: impl CstDecode<crate::api::send::FfiSender>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_sender_to_json",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
+                let output_ok = crate::api::send::FfiSender::to_json(&api_that)?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -2287,6 +2359,10 @@ impl SseDecode for crate::utils::error::PayjoinError {
                 let mut var_message = <String>::sse_decode(deserializer);
                 return crate::utils::error::PayjoinError::InputPairError { message: var_message };
             }
+            21 => {
+                let mut var_message = <String>::sse_decode(deserializer);
+                return crate::utils::error::PayjoinError::SerdeJsonError { message: var_message };
+            }
             _ => {
                 unimplemented!("");
             }
@@ -2889,6 +2965,9 @@ impl flutter_rust_bridge::IntoDart for crate::utils::error::PayjoinError {
             }
             crate::utils::error::PayjoinError::InputPairError { message } => {
                 [20.into_dart(), message.into_into_dart().into_dart()].into_dart()
+            }
+            crate::utils::error::PayjoinError::SerdeJsonError { message } => {
+                [21.into_dart(), message.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -3591,6 +3670,10 @@ impl SseEncode for crate::utils::error::PayjoinError {
             }
             crate::utils::error::PayjoinError::InputPairError { message } => {
                 <i32>::sse_encode(20, serializer);
+                <String>::sse_encode(message, serializer);
+            }
+            crate::utils::error::PayjoinError::SerdeJsonError { message } => {
+                <i32>::sse_encode(21, serializer);
                 <String>::sse_encode(message, serializer);
             }
             _ => {

--- a/rust/src/utils/error.rs
+++ b/rust/src/utils/error.rs
@@ -75,6 +75,9 @@ pub enum PayjoinError {
     InputPairError {
         message: String,
     },
+    SerdeJsonError {
+        message: String,
+    },
 }
 
 macro_rules! from_payjoin_ffi_error {
@@ -125,7 +128,8 @@ from_payjoin_ffi_error!(
     IoError,
     OutputSubstitutionError,
     InputContributionError,
-    InputPairError
+    InputPairError,
+    SerdeJsonError
 );
 from_payjoin_error!(
     InvalidAddress,
@@ -148,7 +152,8 @@ from_payjoin_error!(
     IoError,
     OutputSubstitutionError,
     InputContributionError,
-    InputPairError
+    InputPairError,
+    SerdeJsonError
 );
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
These functions are necessary to persist `Sender` and `Receiver` types in order to keep sessions around asynchronously.

The `Receiver.id()` function was also exposed since it seems to have been overlooked.

based on ~https://github.com/LtbLightning/payjoin-ffi/pull/39~ LtbLightning/payjoin-ffi tag v0.21.1

~This follows #38 and will be rebased on that once it is merged~

In addition this now follows https://github.com/LtbLightning/payjoin-ffi/pull/40 to add another missing but necessary component of the 0.21 release AND includes the bumps in the final commit to actually tag payjoin-flutter 0.21.0