### PR TITLE
expose uri params label and message

### DIFF
--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -494,6 +494,10 @@ WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_as_st
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_check_pj_supported(struct wire_cst_ffi_uri *that);
 
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_label(struct wire_cst_ffi_uri *that);
+
+WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_message(struct wire_cst_ffi_uri *that);
+
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_parse(struct wire_cst_list_prim_u_8_strict *uri);
 
 WireSyncRust2DartDco frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_as_string(struct wire_cst_ffi_url *that);
@@ -790,6 +794,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_amount_sats);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_as_string);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_check_pj_supported);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_label);
+    dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_message);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_parse);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_as_string);
     dummy_var ^= ((int64_t) (void*) frbgen_payjoin_flutter_wire__crate__api__uri__ffi_url_parse);

--- a/lib/src/generated/api/uri.dart
+++ b/lib/src/generated/api/uri.dart
@@ -130,6 +130,14 @@ class FfiUri {
         that: this,
       );
 
+  String? label() => core.instance.api.crateApiUriFfiUriLabel(
+        that: this,
+      );
+
+  String? message() => core.instance.api.crateApiUriFfiUriMessage(
+        that: this,
+      );
+
   static FfiUri parse({required String uri}) =>
       core.instance.api.crateApiUriFfiUriParse(uri: uri);
 

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -62,7 +62,7 @@ class core extends BaseEntrypoint<coreApi, coreApiImpl, coreWire> {
   String get codegenVersion => '2.0.0';
 
   @override
-  int get rustContentHash => 685157858;
+  int get rustContentHash => -1997949636;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -271,6 +271,10 @@ abstract class coreApi extends BaseApi {
   String crateApiUriFfiUriAsString({required FfiUri that});
 
   FfiPjUri crateApiUriFfiUriCheckPjSupported({required FfiUri that});
+
+  String? crateApiUriFfiUriLabel({required FfiUri that});
+
+  String? crateApiUriFfiUriMessage({required FfiUri that});
 
   FfiUri crateApiUriFfiUriParse({required String uri});
 
@@ -2067,6 +2071,50 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   TaskConstMeta get kCrateApiUriFfiUriCheckPjSupportedConstMeta =>
       const TaskConstMeta(
         debugName: "ffi_uri_check_pj_supported",
+        argNames: ["that"],
+      );
+
+  @override
+  String? crateApiUriFfiUriLabel({required FfiUri that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_ffi_uri(that);
+        return wire.wire__crate__api__uri__ffi_uri_label(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_opt_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiUriFfiUriLabelConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiUriFfiUriLabelConstMeta => const TaskConstMeta(
+        debugName: "ffi_uri_label",
+        argNames: ["that"],
+      );
+
+  @override
+  String? crateApiUriFfiUriMessage({required FfiUri that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_ffi_uri(that);
+        return wire.wire__crate__api__uri__ffi_uri_message(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_opt_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiUriFfiUriMessageConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiUriFfiUriMessageConstMeta => const TaskConstMeta(
+        debugName: "ffi_uri_message",
         argNames: ["that"],
       );
 

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -3505,6 +3505,38 @@ class coreWire implements BaseWire {
       _wire__crate__api__uri__ffi_uri_check_pj_supportedPtr.asFunction<
           WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_uri>)>();
 
+  WireSyncRust2DartDco wire__crate__api__uri__ffi_uri_label(
+    ffi.Pointer<wire_cst_ffi_uri> that,
+  ) {
+    return _wire__crate__api__uri__ffi_uri_label(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__uri__ffi_uri_labelPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_uri>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_label');
+  late final _wire__crate__api__uri__ffi_uri_label =
+      _wire__crate__api__uri__ffi_uri_labelPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_uri>)>();
+
+  WireSyncRust2DartDco wire__crate__api__uri__ffi_uri_message(
+    ffi.Pointer<wire_cst_ffi_uri> that,
+  ) {
+    return _wire__crate__api__uri__ffi_uri_message(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__uri__ffi_uri_messagePtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_uri>)>>(
+      'frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_message');
+  late final _wire__crate__api__uri__ffi_uri_message =
+      _wire__crate__api__uri__ffi_uri_messagePtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_ffi_uri>)>();
+
   WireSyncRust2DartDco wire__crate__api__uri__ffi_uri_parse(
     ffi.Pointer<wire_cst_list_prim_u_8_strict> uri,
   ) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "payjoin_ffi"
 version = "0.22.0"
-source = "git+https://github.com/LtbLightning/payjoin-ffi?tag=v0.22.0#f3693b0b21f2a5ca8d3689225464ebdfe4b5b6ff"
+source = "git+https://github.com/riverKanies/payjoin-ffi?branch=expose-uri-label-and-message#b28ddb635762a2983095bbedccf7b9f39358614a"
 dependencies = [
  "base64 0.22.1",
  "bitcoin-ffi",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ bitcoincore-rpc = "0.19.0"
 anyhow = "1.0.68"
 [dependencies]
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", rev = "4cd8e644dbf4e001d71d5fffb232480fa5ff2246" }
-payjoin_ffi = { git = "https://github.com/LtbLightning/payjoin-ffi", tag = "v0.22.0" }
+payjoin_ffi = { git = "https://github.com/riverKanies/payjoin-ffi", branch = "expose-uri-label-and-message" }
 flutter_rust_bridge = "=2.0.0"
 anyhow = "1.0.68"
 tokio = "1.36.0"

--- a/rust/src/api/uri.rs
+++ b/rust/src/api/uri.rs
@@ -135,6 +135,14 @@ impl FfiUri {
         self.0.amount_sats()
     }
     #[frb(sync)]
+    pub fn label(&self) -> Option<String> {
+        self.0.label()
+    }
+    #[frb(sync)]
+    pub fn message(&self) -> Option<String> {
+        self.0.message()
+    }
+    #[frb(sync)]
     pub fn as_string(&self) -> String {
         self.0.as_string()
     }

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -1633,6 +1633,20 @@ pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_check_pj
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_label(
+    that: *mut wire_cst_ffi_uri,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__uri__ffi_uri_label_impl(that)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_message(
+    that: *mut wire_cst_ffi_uri,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__uri__ffi_uri_message_impl(that)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_payjoin_flutter_wire__crate__api__uri__ffi_uri_parse(
     uri: *mut wire_cst_list_prim_u_8_strict,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 685157858;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1997949636;
 
 // Section: executor
 
@@ -1485,6 +1485,42 @@ fn wire__crate__api__uri__ffi_uri_check_pj_supported_impl(
             let api_that = that.cst_decode();
             transform_result_dco::<_, _, crate::utils::error::PayjoinError>((move || {
                 let output_ok = crate::api::uri::FfiUri::check_pj_supported(&api_that)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__uri__ffi_uri_label_impl(
+    that: impl CstDecode<crate::api::uri::FfiUri>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_uri_label",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::uri::FfiUri::label(&api_that))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__uri__ffi_uri_message_impl(
+    that: impl CstDecode<crate::api::uri::FfiUri>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ffi_uri_message",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::uri::FfiUri::message(&api_that))?;
                 Ok(output_ok)
             })())
         },


### PR DESCRIPTION
addresses https://github.com/LtbLightning/payjoin-flutter/issues/48

the dependency on payjoin-ffi should be locked to an updated version that includes this change https://github.com/LtbLightning/payjoin-ffi/pull/44
that's why this is a draft pr for now

Note: locally I had to make some other changes just to get the example running, but I have omitted them here under the assumption that those changes were specific to my environment in some way
for reference here are the local changes included https://github.com/riverKanies/payjoin-flutter/pull/1