### PR TITLE
fix: upgrade cargokit plugin

### DIFF
--- a/cargokit/.github/workflows/check_and_lint.yml
+++ b/cargokit/.github/workflows/check_and_lint.yml
@@ -10,8 +10,8 @@ jobs:
   Flutter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
-      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # 4.1.0
+      - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1 # 2.16.0
       - name: Pub Get
         run: dart pub get --no-precompile
         working-directory: build_tool
@@ -22,5 +22,5 @@ jobs:
         run: dart analyze
         working-directory: build_tool
       - name: Test
-        run: dart test
+        run: flutter test
         working-directory: build_tool

--- a/cargokit/.github/workflows/test_example_plugin_build.yml
+++ b/cargokit/.github/workflows/test_example_plugin_build.yml
@@ -39,7 +39,7 @@ jobs:
             git clone -b advanced https://github.com/irondash/hello_rust_ffi_plugin
             cd hello_rust_ffi_plugin
             git subtree pull --prefix cargokit https://github.com/${{ github.event.pull_request.head.repo.full_name || github.repository }} ${{ steps.extract_branch.outputs.branch }} --squash
-      - uses: subosito/flutter-action@cc97e1648fff6ca5cc647fa67f47e70f7895510b # 2.11.0
+      - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1 # 2.16.0
         with:
           channel: "stable"
       - name: Install GTK
@@ -77,6 +77,10 @@ jobs:
         shell: bash
         working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
-          export JAVA_HOME=$JAVA_HOME_11_X64
+          if [[ $(sysctl hw.optional.arm64) == *"hw.optional.arm64: 1"* ]]; then
+            export JAVA_HOME=$JAVA_HOME_17_arm64
+          else
+            export JAVA_HOME=$JAVA_HOME_17_X64
+          fi
           flutter build apk --${{ matrix.build_mode }} -v
 

--- a/cargokit/build_pod.sh
+++ b/cargokit/build_pod.sh
@@ -49,7 +49,7 @@ do
   fi
 done
 
-"$BASEDIR/run_build_tool.sh" build-pod "$@"
+sh "$BASEDIR/run_build_tool.sh" build-pod "$@"
 
 # Make a symlink from built framework to phony file, which will be used as input to
 # build script. This should force rebuild (podspec currently doesn't support alwaysOutOfDate

--- a/cargokit/build_tool/lib/src/build_tool.dart
+++ b/cargokit/build_tool/lib/src/build_tool.dart
@@ -127,6 +127,10 @@ class PrecompileBinariesCommand extends Command {
         'temp-dir',
         help: 'Directory to store temporary build artifacts',
       )
+      ..addOption(
+        'glibc-version',
+        help: 'GLIBC version to use for linux builds',
+      )
       ..addFlag(
         "verbose",
         abbr: "v",
@@ -195,6 +199,7 @@ class PrecompileBinariesCommand extends Command {
       androidNdkVersion: argResults!['android-ndk-version'] as String?,
       androidMinSdkVersion: androidMinSdkVersion,
       tempDir: argResults!['temp-dir'] as String?,
+      glibcVersion: argResults!['glibc-version'] as String?,
     );
 
     await precompileBinaries.run();

--- a/cargokit/build_tool/lib/src/builder.dart
+++ b/cargokit/build_tool/lib/src/builder.dart
@@ -51,6 +51,8 @@ class BuildEnvironment {
   final int? androidMinSdkVersion;
   final String? javaHome;
 
+  final String? glibcVersion;
+
   BuildEnvironment({
     required this.configuration,
     required this.crateOptions,
@@ -62,6 +64,7 @@ class BuildEnvironment {
     this.androidNdkVersion,
     this.androidMinSdkVersion,
     this.javaHome,
+    this.glibcVersion,
   });
 
   static BuildConfiguration parseBuildConfiguration(String value) {
@@ -125,6 +128,9 @@ class RustBuilder {
     if (!rustup.installedTargets(toolchain)!.contains(target.rust)) {
       rustup.installTarget(target.rust, toolchain: toolchain);
     }
+    if (environment.glibcVersion != null) {
+      rustup.installZigBuild(toolchain);
+    }
   }
 
   CargoBuildOptions? get _buildOptions =>
@@ -142,7 +148,9 @@ class RustBuilder {
         'run',
         _toolchain,
         'cargo',
-        'build',
+        (target.android == null && environment.glibcVersion != null)
+            ? 'zigbuild'
+            : 'build',
         ...extraArgs,
         '--manifest-path',
         manifestPath,
@@ -150,7 +158,10 @@ class RustBuilder {
         environment.crateInfo.packageName,
         if (!environment.configuration.isDebug) '--release',
         '--target',
-        target.rust,
+        target.rust +
+            ((target.android == null && environment.glibcVersion != null)
+                ? '.${environment.glibcVersion!}'
+                : ""),
         '--target-dir',
         environment.targetTempDir,
       ],

--- a/cargokit/build_tool/lib/src/options.dart
+++ b/cargokit/build_tool/lib/src/options.dart
@@ -298,10 +298,7 @@ class CargokitUserOptions {
       }
       userProjectDir = userProjectDir.parent;
     }
-    return CargokitUserOptions(
-      usePrecompiledBinaries: true,
-      verboseLogging: false,
-    );
+    return CargokitUserOptions._();
   }
 
   final bool usePrecompiledBinaries;

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -26,6 +26,7 @@ class PrecompileBinaries {
     this.androidNdkVersion,
     this.androidMinSdkVersion,
     this.tempDir,
+    this.glibcVersion,
   });
 
   final PrivateKey privateKey;
@@ -37,6 +38,7 @@ class PrecompileBinaries {
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
   final String? tempDir;
+  final String? glibcVersion;
 
   static String fileName(Target target, String name) {
     return '${target.rust}_$name';
@@ -93,6 +95,7 @@ class PrecompileBinaries {
       androidSdkPath: androidSdkLocation,
       androidNdkVersion: androidNdkVersion,
       androidMinSdkVersion: androidMinSdkVersion,
+      glibcVersion: glibcVersion,
     );
 
     final rustup = Rustup();

--- a/cargokit/build_tool/lib/src/rustup.dart
+++ b/cargokit/build_tool/lib/src/rustup.dart
@@ -33,14 +33,27 @@ class Rustup {
     required String toolchain,
   }) {
     log.info("Installing Rust target: $target");
-    runCommand("rustup", [
-      'target',
-      'add',
-      '--toolchain',
-      toolchain,
-      target,
-    ]);
+    runCommand("rustup", ['target', 'add', '--toolchain', toolchain, target]);
     _installedTargets(toolchain)?.add(target);
+  }
+
+  bool _didInstallZigBuild = false;
+
+  void installZigBuild(String toolchain) {
+    if (_didInstallZigBuild) {
+      return;
+    }
+
+    log.info("Installing Zig build");
+    runCommand("rustup", [
+      'run',
+      toolchain,
+      'cargo',
+      'install',
+      '--locked',
+      'cargo-zigbuild',
+    ]);
+    _didInstallZigBuild = true;
   }
 
   final List<_Toolchain> _installedToolchains;

--- a/cargokit/build_tool/lib/src/target.dart
+++ b/cargokit/build_tool/lib/src/target.dart
@@ -44,6 +44,10 @@ class Target {
       flutter: 'windows-x64',
     ),
     Target(
+      rust: 'aarch64-pc-windows-msvc',
+      flutter: 'windows-arm64',
+    ),
+    Target(
       rust: 'x86_64-unknown-linux-gnu',
       flutter: 'linux-x64',
     ),
@@ -51,6 +55,7 @@ class Target {
       rust: 'aarch64-unknown-linux-gnu',
       flutter: 'linux-arm64',
     ),
+    Target(rust: 'riscv64gc-unknown-linux-gnu', flutter: 'linux-riscv64'),
     Target(
       rust: 'x86_64-apple-darwin',
       darwinPlatform: 'macosx',
@@ -106,9 +111,11 @@ class Target {
     if (Platform.isLinux) {
       // Right now we don't support cross-compiling on Linux. So we just return
       // the host target.
-      final arch = runCommand('arch', []).stdout as String;
-      if (arch.trim() == 'aarch64') {
+      final arch = (runCommand('arch', []).stdout as String).trim();
+      if (arch == 'aarch64') {
         return [Target.forRustTriple('aarch64-unknown-linux-gnu')!];
+      } else if (arch == 'riscv64') {
+        return [Target.forRustTriple('riscv64gc-unknown-linux-gnu')!];
       } else {
         return [Target.forRustTriple('x86_64-unknown-linux-gnu')!];
       }

--- a/cargokit/cmake/cargokit.cmake
+++ b/cargokit/cmake/cargokit.cmake
@@ -50,6 +50,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     else()
         set(SCRIPT_EXTENSION ".sh")
         set(IMPORT_LIB_EXTENSION "")
+        execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
     endif()
 
     # Using generators in custom command is only supported in CMake 3.20+
@@ -74,6 +75,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
             VERBATIM
         )
     endif()
+
 
     set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/_phony_" PROPERTIES SYMBOLIC TRUE)
 

--- a/cargokit/cmake/resolve_symlinks.ps1
+++ b/cargokit/cmake/resolve_symlinks.ps1
@@ -14,14 +14,21 @@ function Resolve-Symlinks {
         if ($realPath -and !$realPath.EndsWith($separator)) {
             $realPath += $separator
         }
-        $realPath += $part
+
+        $realPath += $part.Replace('\', '/')
+
+        # The slash is important when using Get-Item on Drive letters in pwsh.
+        if (-not($realPath.Contains($separator)) -and $realPath.EndsWith(':')) {
+            $realPath += '/'
+        }
+
         $item = Get-Item $realPath
-        if ($item.Target) {
-            $realPath = $item.Target.Replace('\', '/')
+        if ($item.LinkTarget) {
+            $realPath = $item.LinkTarget.Replace('\', '/')
         }
     }
     $realPath
 }
 
-$path=Resolve-Symlinks -Path $args[0]
+$path = Resolve-Symlinks -Path $args[0]
 Write-Host $path

--- a/cargokit/gradle/plugin.gradle
+++ b/cargokit/gradle/plugin.gradle
@@ -56,6 +56,12 @@ abstract class CargoKitBuildTask extends DefaultTask {
 
         def rootProjectDir = project.rootProject.projectDir
 
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            project.exec {
+                commandLine 'chmod', '+x', path
+            }
+        }
+
         project.exec {
             executable path
             args "build-gradle"
@@ -86,7 +92,7 @@ class CargoKitPlugin implements Plugin<Project> {
    private Plugin _findFlutterPlugin(Map projects) {
         for (project in projects) {
             for (plugin in project.value.getPlugins()) {
-                if (plugin.class.name == "FlutterPlugin") {
+                if (plugin.class.name == "com.flutter.gradle.FlutterPlugin") {
                     return plugin;
                 }
             }
@@ -111,7 +117,11 @@ class CargoKitPlugin implements Plugin<Project> {
 
         def cargoBuildDir = "${project.buildDir}/build"
 
-        plugin.project.android.applicationVariants.all { variant ->
+        // Determine if the project is an application or library
+        def isApplication = plugin.project.plugins.hasPlugin('com.android.application')
+        def variants = isApplication ? plugin.project.android.applicationVariants : plugin.project.android.libraryVariants
+
+        variants.all { variant ->
 
             final buildType = variant.buildType.name
 
@@ -119,7 +129,7 @@ class CargoKitPlugin implements Plugin<Project> {
             def jniLibs = project.android.sourceSets.maybeCreate(buildType).jniLibs;
             jniLibs.srcDir(new File(cargoOutputDir))
 
-            def platforms = plugin.getTargetPlatforms().collect()
+            def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
 
             // Same thing addFlutterDependencies does in flutter.gradle
             if (buildType == "debug") {

--- a/cargokit/run_build_tool.sh
+++ b/cargokit/run_build_tool.sh
@@ -77,6 +77,11 @@ if [ ! -f "$PACKAGE_HASH_FILE" ]; then
     echo "$PACKAGE_HASH" > "$PACKAGE_HASH_FILE"
 fi
 
+# Rebuild the tool if it was deleted by Android Studio
+if [ ! -f "bin/build_tool_runner.dill" ]; then
+  "$DART" compile kernel bin/build_tool_runner.dart
+fi
+
 set +e
 
 "$DART" bin/build_tool_runner.dill "$@"


### PR DESCRIPTION
Since Flutter change their plugin api Cargokit won't build on newer flutter versions after 3.29.3

Updating Cargokit fixes it 

https://github.com/irondash/cargokit/issues/93